### PR TITLE
Don't log unless lightninglib is ready

### DIFF
--- a/init.go
+++ b/init.go
@@ -56,6 +56,7 @@ var (
 	breezClientConnection *grpc.ClientConn
 	notificationsChan     = make(chan data.NotificationEvent)
 	appWorkingDir         string
+	isReady               bool
 )
 
 type config struct {
@@ -125,6 +126,7 @@ func onReady() {
 		return
 	}
 	notificationsChan <- data.NotificationEvent{Type: data.NotificationEvent_READY}
+	isReady = true
 
 	go func() {
 		go watchRoutingNodeConnection()

--- a/init.go
+++ b/init.go
@@ -7,14 +7,16 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"path"
+	"strings"
+	"sync/atomic"
+
 	"github.com/breez/breez/data"
 	"github.com/breez/breez/lightningclient"
 	"github.com/breez/lightninglib/daemon"
 	"github.com/breez/lightninglib/lnrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"path"
-	"strings"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -56,7 +58,7 @@ var (
 	breezClientConnection *grpc.ClientConn
 	notificationsChan     = make(chan data.NotificationEvent)
 	appWorkingDir         string
-	isReady               bool
+	isReady               int32
 )
 
 type config struct {
@@ -126,7 +128,7 @@ func onReady() {
 		return
 	}
 	notificationsChan <- data.NotificationEvent{Type: data.NotificationEvent_READY}
-	isReady = true
+	atomic.StoreInt32(&isReady, 1)
 
 	go func() {
 		go watchRoutingNodeConnection()

--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package breez
 
 import (
 	"github.com/breez/lightninglib/daemon"
+	"sync/atomic"
 )
 
 var log = daemon.BackendLog().Logger("BRUI")
@@ -10,7 +11,7 @@ var log = daemon.BackendLog().Logger("BRUI")
 Log a message to lightninglib's logging system
 */
 func Log(msg string, lvl string) {
-	if isReady {
+	if atomic.LoadInt32(&isReady) == 1 {
 		switch lvl {
 		case "FINEST":
 		case "FINER":

--- a/log.go
+++ b/log.go
@@ -10,23 +10,25 @@ var log = daemon.BackendLog().Logger("BRUI")
 Log a message to lightninglib's logging system
 */
 func Log(msg string, lvl string) {
-	switch lvl {
-	case "FINEST":
-	case "FINER":
-	case "FINE":
-		log.Tracef(msg)
-	case "CONFIG":
-		log.Debugf(msg)
-	case "INFO":
-		log.Infof(msg)
-	case "WARNING":
-		log.Warnf(msg)
-	case "SEVERE":
-		log.Errorf(msg)
-	case "SHOUT":
-		log.Criticalf(msg)
-	default:
-		log.Infof(msg)
+	if isReady {
+		switch lvl {
+		case "FINEST":
+		case "FINER":
+		case "FINE":
+			log.Tracef(msg)
+		case "CONFIG":
+			log.Debugf(msg)
+		case "INFO":
+			log.Infof(msg)
+		case "WARNING":
+			log.Warnf(msg)
+		case "SEVERE":
+			log.Errorf(msg)
+		case "SHOUT":
+			log.Criticalf(msg)
+		default:
+			log.Infof(msg)
+		}
 	}
 }
 


### PR DESCRIPTION
In case Breez is terminated some services may want to log and since logging is done through lightninglib this is not available and will cause a SIGABRT. But there is still value in logging to breez.log when this is available so add a runtime check to see if lightninglib is initialised