### PR TITLE
make sessionID mandatory for creating new sessions

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -243,7 +243,7 @@ CreateRatchetSession is part of the binding inteface which is delegated to breez
 */
 func CreateRatchetSession(request []byte) ([]byte, error) {
 	var err error
-	var sessionID, secret, pubKey string
+	var secret, pubKey string
 
 	unmarshaledRequest := &data.CreateRatchetSessionRequest{}
 	if err := proto.Unmarshal(request, unmarshaledRequest); err != nil {
@@ -252,7 +252,7 @@ func CreateRatchetSession(request []byte) ([]byte, error) {
 
 	//if has secret then we are initiators
 	if unmarshaledRequest.Secret == "" {
-		sessionID, secret, pubKey, err = doubleratchet.NewSession()
+		secret, pubKey, err = doubleratchet.NewSession(unmarshaledRequest.SessionID)
 	} else {
 		err = doubleratchet.NewSessionWithRemoteKey(unmarshaledRequest.SessionID, unmarshaledRequest.Secret, unmarshaledRequest.RemotePubKey)
 	}
@@ -260,7 +260,7 @@ func CreateRatchetSession(request []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return marshalResponse(&data.CreateRatchetSessionReply{SessionID: sessionID, Secret: secret, PubKey: pubKey}, nil)
+	return marshalResponse(&data.CreateRatchetSessionReply{SessionID: unmarshaledRequest.SessionID, Secret: secret, PubKey: pubKey}, nil)
 }
 
 /*

--- a/doubleratchet/doublerachet.go
+++ b/doubleratchet/doublerachet.go
@@ -48,7 +48,7 @@ This function creates a session and stores its state in the SessionStore
 Following this operation the caller can imediately use Encrypt/Decrypt by
 providing the sessionID as identifier.
 */
-func NewSession() (sessionID, secret, pubKey string, err error) {
+func NewSession(sessionID string) (secret, pubKey string, err error) {
 	crypto := doubleratchet.DefaultCrypto{}
 
 	var sk [32]byte
@@ -57,11 +57,7 @@ func NewSession() (sessionID, secret, pubKey string, err error) {
 		return
 	}
 
-	sID, err := generateSessionID()
-	if err != nil {
-		return
-	}
-	if err = addInitiatedSessionID([]byte(sID)); err != nil {
+	if err = addInitiatedSessionID([]byte(sessionID)); err != nil {
 		return
 	}
 
@@ -69,13 +65,13 @@ func NewSession() (sessionID, secret, pubKey string, err error) {
 	if err != nil {
 		return
 	}
-	_, err = doubleratchet.New([]byte(sID), sk, keyPair, &BoltDBSessionStorage{})
+	_, err = doubleratchet.New([]byte(sessionID), sk, keyPair, &BoltDBSessionStorage{})
 	if err != nil {
 		return
 	}
 
 	publicKey := keyPair.PublicKey()
-	return sID, hex.EncodeToString(sk[:]), hex.EncodeToString(publicKey[:]), nil
+	return hex.EncodeToString(sk[:]), hex.EncodeToString(publicKey[:]), nil
 }
 
 /*

--- a/doubleratchet/doubleratchet_test.go
+++ b/doubleratchet/doubleratchet_test.go
@@ -78,7 +78,8 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.Error(err)
 	}
 	defer destroyDB()
-	initiatorID, secret, pubKey, err := NewSession()
+	initiatorID := "initiatorSession"
+	secret, pubKey, err := NewSession(initiatorID)
 	if err != nil {
 		t.Error(err)
 		return
@@ -110,7 +111,8 @@ func TestOutOfOrderMessages(t *testing.T) {
 		t.Error(err)
 	}
 	defer destroyDB()
-	initiatorID, secret, pubKey, err := NewSession()
+	initiatorID := "initiatorSession"
+	secret, pubKey, err := NewSession(initiatorID)
 	if err != nil {
 		t.Error(err)
 		return
@@ -159,7 +161,8 @@ func TestInitiatedSessions(t *testing.T) {
 		t.Error(err)
 	}
 	defer destroyDB()
-	initiatorID, secret, pubKey, err := NewSession()
+	initiatorID := "initiatorSession"
+	secret, pubKey, err := NewSession(initiatorID)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
This PR is to make the sessionID mandatory for creating new ratchet sessions.
This is because session identifiers identify sessions between users and may be controlled by an external server.