### PR TITLE
Ensure channel opened

### DIFF
--- a/account_notify.go
+++ b/account_notify.go
@@ -1,0 +1,89 @@
+package breez
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	breezservice "github.com/breez/breez/breez"
+)
+
+var (
+	openChanneNotificationTokens []string
+	subscriptionsSync            sync.Mutex
+)
+
+//RegisterReceivePaymentReadyNotification register in breez server for notification regarding the confirmation
+//of an existing pending channel. If there is not channels and no pending channels then this function waits for
+//for a channel to be opened by only adding the register logic to the paymentReadySubscriptions
+func RegisterReceivePaymentReadyNotification(token string) error {
+	channelPoints, err := getBreezOpenChannelsPoints()
+	if err != nil {
+		return err
+	}
+	if len(channelPoints) > 0 {
+		return nil
+	}
+
+	registered, err := registerPendingChannelConfirmation(token)
+	if !registered {
+		//we have no channel and no pending channel with routing node, just save the token for later
+		subscriptionsSync.Lock()
+		defer subscriptionsSync.Unlock()
+		openChanneNotificationTokens = append(openChanneNotificationTokens, token)
+	}
+
+	return nil
+}
+
+func trackOpenedChannel() {
+	ticker := time.NewTicker(time.Minute * 1)
+	for {
+		select {
+		case <-ticker.C:
+			channelPoints, err := getBreezOpenChannelsPoints()
+			if err == nil && len(channelPoints) > 0 {
+				ticker.Stop()
+				onRoutingNodeOpenedChannel()
+			}
+		case <-quitChan:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func registerPendingChannelConfirmation(token string) (bool, error) {
+
+	pendingChannelPoint, err := getPendingBreezChannelPoint()
+	if err != nil {
+		return false, err
+	}
+	if pendingChannelPoint == "" {
+		return false, nil
+	}
+
+	c, ctx, cancel := getFundManager()
+	defer cancel()
+	_, err = c.RegisterTransactionConfirmation(ctx,
+		&breezservice.RegisterTransactionConfirmationRequest{
+			NotificationToken: token,
+			TxID:              strings.Split(pendingChannelPoint, ":")[0],
+			NotificationType:  breezservice.RegisterTransactionConfirmationRequest_READY_RECEIVE_PAYMENT,
+		})
+	return err != nil, err
+}
+
+func onRoutingNodePendingChannel() {
+	subscriptionsSync.Lock()
+	defer subscriptionsSync.Unlock()
+	for _, token := range openChanneNotificationTokens {
+		registerPendingChannelConfirmation(token)
+	}
+	openChanneNotificationTokens = nil
+	onAccountChanged()
+}
+
+func onRoutingNodeOpenedChannel() {
+	onAccountChanged()
+}

--- a/chain.go
+++ b/chain.go
@@ -105,5 +105,6 @@ func watchOnChainState() {
 		}
 		log.Infof("watchOnChainState sending account change notification")
 		onAccountChanged()
+		ensureRoutingChannelOpened()
 	}
 }

--- a/connect.go
+++ b/connect.go
@@ -64,14 +64,7 @@ func onRoutingNodeConnectionChanged(connected bool) {
 	if connected {
 		accData, _ := calculateAccount()
 		go updateNodeChannelPolicy(accData.Id)
-
-		if accData.Status == data.Account_WAITING_DEPOSIT {
-			createChannelGroup.Do("createChannel", func() (interface{}, error) {
-				createChannel(accData.Id)
-				return nil, nil
-			})
-			onAccountChanged()
-		}
+		ensureRoutingChannelOpened()
 	}
 }
 

--- a/init.go
+++ b/init.go
@@ -313,9 +313,9 @@ func initLightningClient() error {
 }
 
 func connectOnStartup() {
-	channelPoints, err := getOpenChannelsPoints()
+	channelPoints, err := getBreezOpenChannelsPoints()
 	if err != nil {
-		log.Errorf("connectOnStartup: error in getOpenChannelsPoints", err)
+		log.Errorf("connectOnStartup: error in getBreezOpenChannelsPoints", err)
 		return
 	}
 	pendingChannels, err := lightningClient.PendingChannels(context.Background(), &lnrpc.PendingChannelsRequest{})


### PR DESCRIPTION
This PR makes sure breez will always try to open channel when there is no such active.
There are two points that are watched and check if action is needed:
1. On startup
2. After every on chain transaction - to make sure it is not a close channel transaction.
Also the account logic is split into two files (account.go, account_notify.go).
The whole logic of ensuring that the channel is opened should be simplified when the SubscribeChannels grpc endpoint will be merged (https://github.com/lightningnetwork/lnd/pull/1988).