### PR TITLE
Neutrino job

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -25,6 +25,7 @@ JobCanceler is the interface to return when scheuling a job to allow the caller 
 any time
 */
 type JobController interface {
+	Start() error
 	Stop() error
 	WaitForShutdown()
 }
@@ -46,7 +47,7 @@ func Start(workingDir string, tempDir string, notifier BreezNotifier) (err error
 StartSyncJob starts breez only to reach synchronized state.
 The daemon closes itself automatically when reaching this state.
 */
-func StartSyncJob(workingDir string) (JobController, error) {
+func NewSyncJob(workingDir string) (JobController, error) {
 	job, err := sync.NewJob(workingDir)
 	if err != nil {
 		return nil, err

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/breez/breez/bootstrap"
 	"github.com/breez/breez/data"
 	"github.com/breez/breez/doubleratchet"
+	"github.com/breez/breez/sync"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -17,6 +18,15 @@ BreezNotifier is the interface that is used to send notifications to the user of
 */
 type BreezNotifier interface {
 	Notify(notificationEvent []byte)
+}
+
+/*
+JobCanceler is the interface to return when scheuling a job to allow the caller to cancel at
+any time
+*/
+type JobController interface {
+	Stop() error
+	WaitForShutdown()
 }
 
 /*
@@ -36,9 +46,12 @@ func Start(workingDir string, tempDir string, notifier BreezNotifier) (err error
 StartSyncJob starts breez only to reach synchronized state.
 The daemon closes itself automatically when reaching this state.
 */
-func StartSyncJob(workingDir string) error {
-	_, err := breez.Start(workingDir, true)
-	return err
+func StartSyncJob(workingDir string) (JobController, error) {
+	job, err := sync.NewJob(workingDir)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
 }
 
 /*

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/btcsuite/btcd v0.0.0-20180903232927-cff30e1d23fc
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a
+	github.com/btcsuite/btcwallet v0.0.0-20181120233725-7ad4f1e81d78
 	github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/lightninglabs/neutrino v0.0.0-20181102193151-641af1ca5561
 	github.com/status-im/doubleratchet v0.0.0-20181102064121-4dcb6cba284a
 	github.com/urfave/cli v1.18.0
 	go.etcd.io/bbolt v1.3.0

--- a/init.go
+++ b/init.go
@@ -75,6 +75,9 @@ var (
 	quitChan                     chan struct{}
 )
 
+/*
+Config holds the breez configuration
+*/
 type Config struct {
 	RoutingNodeHost   string `long:"routingnodehost"`
 	RoutingNodePubKey string `long:"routingnodepubkey"`
@@ -82,6 +85,19 @@ type Config struct {
 	Network           string `long:"network"`
 	GrpcKeepAlive     bool   `long:"grpckeepalive"`
 	BootstrapURL      string `long:"bootstrap"`
+
+	//Job Options
+	JobCfg JobConfig `group:"Job Options"`
+}
+
+/*
+JobConfig hodls the job configuration
+*/
+type JobConfig struct {
+	MaxPeers       int      `long:"maxpeers"`
+	BanDuration    int      `long:"banduration"`
+	ConnectTimeout int      `long:"connecttimeout"`
+	ConnectedPeers []string `long:"peer"`
 }
 
 func getBreezClientConnection() *grpc.ClientConn {

--- a/sync/chainservice.go
+++ b/sync/chainservice.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/breez/breez"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
 )
@@ -38,11 +36,6 @@ func newNeutrino(workingDir string, network string, jobConfig *breez.JobConfig) 
 		return nil, nil, fmt.Errorf("Unrecognized network %v", network)
 	}
 
-	logger := btclog.NewBackend(os.Stdout)
-	chainLogger := logger.Logger("CHAIN")
-	chainLogger.SetLevel(btclog.LevelDebug)
-	neutrino.UseLogger(chainLogger)
-
 	//if neutrino directory or wallet directory do not exit then
 	//We exit silently.
 	dataPath := strings.Replace(directoryPattern, "{{network}}", network, -1)
@@ -54,7 +47,6 @@ func newNeutrino(workingDir string, network string, jobConfig *breez.JobConfig) 
 	//os.MkdirAll(path.Join(workingDir, dataPath), os.ModePerm)
 	db, err := walletdb.Create("bdb", neutrinoDB)
 	if err != nil {
-		log.Printf("Error opening DB: %s\n", err)
 		return nil, nil, err
 	}
 

--- a/sync/chainservice.go
+++ b/sync/chainservice.go
@@ -1,0 +1,73 @@
+package sync
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/breez/breez"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino"
+)
+
+const (
+	directoryPattern = "data/chain/bitcoin/{{network}}/"
+)
+
+/*
+NewChainService creates a chain service that the sync job uses
+in order to fetch chain data such as headers, filters, etc...
+*/
+func newNeutrino(workingDir string, network string, jobConfig *breez.JobConfig) (walletdb.DB, *neutrino.ChainService, error) {
+	var chainParams *chaincfg.Params
+	switch network {
+	case "testnet":
+		chainParams = &chaincfg.TestNet3Params
+	case "simnet":
+		chainParams = &chaincfg.SimNetParams
+	case "mainnet":
+		chainParams = &chaincfg.MainNetParams
+	}
+
+	if chainParams == nil {
+		return nil, nil, fmt.Errorf("Unrecognized network %v", network)
+	}
+
+	logger := btclog.NewBackend(os.Stdout)
+	chainLogger := logger.Logger("CHAIN")
+	chainLogger.SetLevel(btclog.LevelDebug)
+	neutrino.UseLogger(chainLogger)
+
+	//if neutrino directory or wallet directory do not exit then
+	//We exit silently.
+	dataPath := strings.Replace(directoryPattern, "{{network}}", network, -1)
+	neutrinoDataDir := path.Join(workingDir, dataPath)
+	neutrinoDB := path.Join(neutrinoDataDir, "neutrino.db")
+	if _, err := os.Stat(neutrinoDB); os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	//os.MkdirAll(path.Join(workingDir, dataPath), os.ModePerm)
+	db, err := walletdb.Create("bdb", neutrinoDB)
+	if err != nil {
+		log.Printf("Error opening DB: %s\n", err)
+		return nil, nil, err
+	}
+
+	neutrinoConfig := neutrino.Config{
+		DataDir:      neutrinoDataDir,
+		Database:     db,
+		ChainParams:  *chainParams,
+		ConnectPeers: jobConfig.ConnectedPeers,
+	}
+
+	neutrino.MaxPeers = jobConfig.MaxPeers
+	neutrino.BanDuration = time.Duration(jobConfig.BanDuration) * time.Second
+	neutrino.QueryPeerConnectTimeout = time.Duration(jobConfig.ConnectTimeout) * time.Second
+	chainService, err := neutrino.NewChainService(neutrinoConfig)
+	return db, chainService, err
+}

--- a/sync/init.go
+++ b/sync/init.go
@@ -1,12 +1,27 @@
 package sync
 
 import (
+	"os"
 	"sync"
 
 	"github.com/breez/breez"
+	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
 )
+
+func initJobLogger(workingDir, network string) (btclog.Logger, error) {
+	filename := workingDir + "/logs/bitcoin/" + network + "/lnd.log"
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := btclog.NewBackend(f)
+	log := logger.Logger("SYNC")
+	log.SetLevel(btclog.LevelDebug)
+	return log, nil
+}
 
 /*
 Job contains a running job info.
@@ -19,6 +34,7 @@ type Job struct {
 	db         walletdb.DB
 	started    int32
 	shutdown   int32
+	log        btclog.Logger
 	wg         sync.WaitGroup
 }
 
@@ -32,7 +48,13 @@ func NewJob(workingDir string) (*Job, error) {
 		return nil, err
 	}
 
+	log, err := initJobLogger(workingDir, config.Network)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Job{
+		log:        log,
 		workingDir: workingDir,
 		network:    config.Network,
 		config:     config.JobCfg,

--- a/sync/init.go
+++ b/sync/init.go
@@ -1,0 +1,40 @@
+package sync
+
+import (
+	"sync"
+
+	"github.com/breez/breez"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightninglabs/neutrino"
+)
+
+/*
+Job contains a running job info.
+*/
+type Job struct {
+	workingDir string
+	network    string
+	config     breez.JobConfig
+	neutrino   *neutrino.ChainService
+	db         walletdb.DB
+	started    int32
+	shutdown   int32
+	wg         sync.WaitGroup
+}
+
+/*
+NewJob crates a new SyncJob and given a directory for this job.
+It is assumed that a config file exists in this directory.
+*/
+func NewJob(workingDir string) (*Job, error) {
+	config, err := breez.GetConfig(workingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Job{
+		workingDir: workingDir,
+		network:    config.Network,
+		config:     config.JobCfg,
+	}, nil
+}


### PR DESCRIPTION
This PR introduces a better (and faster) way to sync (download the compact filters).
In general it adds the following:
1. Job structure with Start/Stop functions.
2. Starting a job means running neutrino, let it sync and fetch all filters.
3. Stop shutdowns the job immediately.

It is intended to be run in the background at a preconfigured interval so when app starts it will be synchronized almost immediately.