### PR TITLE
Package config

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/breez/breez"
+	"github.com/breez/breez/config"
 )
 
 var (
@@ -41,7 +41,7 @@ func copyFile(src, dest string) error {
 // PutFiles restore each received files in the right directory
 // before lightninglib starts
 func PutFiles(workingDir string, files []string) error {
-	c, err := breez.GetConfig(workingDir)
+	c, err := config.GetConfig(workingDir)
 	if err != nil {
 		return err
 	}

--- a/config/init.go
+++ b/config/init.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"errors"
+	"path"
+	"sync"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+const (
+	configFile = "breez.conf"
+)
+
+var (
+	cfg         *Config
+	configError error
+	once        sync.Once
+)
+
+/*
+JobConfig hodls the job configuration
+*/
+type JobConfig struct {
+	ConnectedPeers []string `long:"peer"`
+}
+
+/*
+Config holds the breez configuration
+*/
+type Config struct {
+	RoutingNodeHost   string `long:"routingnodehost"`
+	RoutingNodePubKey string `long:"routingnodepubkey"`
+	BreezServer       string `long:"breezserver"`
+	Network           string `long:"network"`
+	GrpcKeepAlive     bool   `long:"grpckeepalive"`
+	BootstrapURL      string `long:"bootstrap"`
+
+	//Job Options
+	JobCfg JobConfig `group:"Job Options"`
+}
+
+// GetConfig returns the config object
+func GetConfig(workingDir string) (*Config, error) {
+	once.Do(func() {
+		configError = initConfig(workingDir)
+	})
+	return cfg, configError
+}
+
+func initConfig(workingDir string) error {
+	c := &Config{}
+	if err := flags.IniParse(path.Join(workingDir, configFile), c); err != nil {
+		return err
+	}
+	if len(c.RoutingNodeHost) == 0 || len(c.RoutingNodePubKey) == 0 {
+		return errors.New("Breez must have routing node defined in the configuration file")
+	}
+
+	cfg = c
+	return nil
+}

--- a/sync/chainservice.go
+++ b/sync/chainservice.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/breez/breez"
+	"github.com/breez/breez/config"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
@@ -20,7 +20,7 @@ const (
 NewChainService creates a chain service that the sync job uses
 in order to fetch chain data such as headers, filters, etc...
 */
-func newNeutrino(workingDir string, network string, jobConfig *breez.JobConfig) (walletdb.DB, *neutrino.ChainService, error) {
+func newNeutrino(workingDir string, network string, jobConfig *config.JobConfig) (walletdb.DB, *neutrino.ChainService, error) {
 	var chainParams *chaincfg.Params
 	switch network {
 	case "testnet":

--- a/sync/init.go
+++ b/sync/init.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/breez/breez"
+	"github.com/breez/breez/config"
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
@@ -29,7 +29,7 @@ Job contains a running job info.
 type Job struct {
 	workingDir string
 	network    string
-	config     breez.JobConfig
+	config     config.JobConfig
 	neutrino   *neutrino.ChainService
 	db         walletdb.DB
 	started    int32
@@ -43,7 +43,7 @@ NewJob crates a new SyncJob and given a directory for this job.
 It is assumed that a config file exists in this directory.
 */
 func NewJob(workingDir string) (*Job, error) {
-	config, err := breez.GetConfig(workingDir)
+	config, err := config.GetConfig(workingDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR moves the config parsing and validating to its own package.
The main reason is so we can run a dedicated and self contained code, like job, shared neutrino for example, without depending on breez main package.
Since breez depends on this shared code the opposite dependency is not even possible, creating circular dependency.
In addition it isolate the configuration from the entry points (lightninglib, job) allowing multiple entry points operate without depending on each other.