### PR TITLE
Shared logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/breez/breez
 
 require (
 	github.com/awalterschulze/gographviz v0.0.0-20160912181450-761fd5fbb34e
-	github.com/breez/lightninglib v0.0.0-20190121133348-f6f17f8b366c
+	github.com/breez/lightninglib v0.0.0-20190122105825-e1cb01b3038c
 	github.com/btcsuite/btcd v0.0.0-20180903232927-cff30e1d23fc
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a
@@ -10,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/jrick/logrotate v1.0.0
 	github.com/lightninglabs/neutrino v0.0.0-20181102193151-641af1ca5561
 	github.com/status-im/doubleratchet v0.0.0-20181102064121-4dcb6cba284a
 	github.com/urfave/cli v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -93,10 +93,14 @@ github.com/breez/lightninglib v0.0.0-20190120131744-899d00e753e1 h1:4/b4qlB7/si9
 github.com/breez/lightninglib v0.0.0-20190120131744-899d00e753e1/go.mod h1:ohqrtfneBBAABYc/EDioLRoUR8LZ1+VKBYYIWL+79V0=
 github.com/breez/lightninglib v0.0.0-20190121133348-f6f17f8b366c h1:LOKTbP8RQqTsqJd1PJltq9aRv2fG/4wbkFQ0XzRRF5Q=
 github.com/breez/lightninglib v0.0.0-20190121133348-f6f17f8b366c/go.mod h1:ohqrtfneBBAABYc/EDioLRoUR8LZ1+VKBYYIWL+79V0=
+github.com/breez/lightninglib v0.0.0-20190122105825-e1cb01b3038c h1:ekgq5FeabR6UcownIeWw69wmnj3MtSCc9bgWRYU1bS0=
+github.com/breez/lightninglib v0.0.0-20190122105825-e1cb01b3038c/go.mod h1:ohqrtfneBBAABYc/EDioLRoUR8LZ1+VKBYYIWL+79V0=
 github.com/breez/neutrino v0.0.0-20181023044851-1943c07c9804 h1:GPbLS0rSo+fhMQe04V66s2oP6RocdtG6nxRJ1P7M2Xk=
 github.com/breez/neutrino v0.0.0-20181023044851-1943c07c9804/go.mod h1:l720ah/7jc5nqsjW0O4ZjKHj33egitv8TKBHXmphyo8=
 github.com/breez/neutrino v0.0.0-20181025065603-14bd66aff1db h1:m+VblI90ZFNqXdXZFy4O3Z3+a54NPq/oUt47DiU4/40=
 github.com/breez/neutrino v0.0.0-20181025065603-14bd66aff1db/go.mod h1:l720ah/7jc5nqsjW0O4ZjKHj33egitv8TKBHXmphyo8=
+github.com/breez/neutrino v0.0.0-20181115061052-77f47710fcc4 h1:556uXozMCBu7c1D2OaVFi+MPT8FCiWBR6aUBuEh80Do=
+github.com/breez/neutrino v0.0.0-20181115061052-77f47710fcc4/go.mod h1:l720ah/7jc5nqsjW0O4ZjKHj33egitv8TKBHXmphyo8=
 github.com/breez/neutrino v0.0.0-20190114145151-3b06e2d8a6dd h1:3GbAtH4RxgYzCdSWMy4Loz9dHyc63BTwZsipFRSaRAI=
 github.com/breez/neutrino v0.0.0-20190114145151-3b06e2d8a6dd/go.mod h1:l720ah/7jc5nqsjW0O4ZjKHj33egitv8TKBHXmphyo8=
 github.com/breez/neutrino v0.0.0-20190114164758-b175c357c30e h1:FcIJQykQ5EkvSpWpMPntRpIc2DLKNDlmDJjFlcBvRT8=

--- a/log.go
+++ b/log.go
@@ -1,11 +1,5 @@
 package breez
 
-import (
-	"github.com/breez/lightninglib/daemon"
-)
-
-var log = daemon.BackendLog().Logger("BRUI")
-
 /*
 Log a message to lightninglib's logging system
 */
@@ -30,6 +24,9 @@ func Log(msg string, lvl string) {
 	}
 }
 
+/*
+GetLogPath returns the log file path.
+*/
 func GetLogPath() string {
 	return appWorkingDir + "/logs/bitcoin/" + cfg.Network + "/lnd.log"
 }

--- a/log/init.go
+++ b/log/init.go
@@ -1,0 +1,84 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/breez/breez/config"
+	"github.com/btcsuite/btclog"
+	"github.com/jrick/logrotate/rotator"
+)
+
+var (
+	initBackend sync.Once
+	logBackend  *btclog.Backend
+	logWriter   *io.PipeWriter
+	initError   error
+)
+
+/*
+Writer is the implementatino of io.Writer interface required for logging
+*/
+type Writer struct {
+	writer io.Writer
+}
+
+func (w *Writer) Write(b []byte) (int, error) {
+	os.Stdout.Write(b)
+	if w.writer != nil {
+		w.writer.Write(b)
+	}
+	return len(b), nil
+}
+
+/*
+GetLogBackend ensure log backend is initialized and return the LogBackend singleton.
+*/
+func GetLogBackend(workingDir string) (*btclog.Backend, error) {
+	initLog(workingDir)
+	return logBackend, initError
+}
+
+/*
+GetLogWriter ensure log backend is initialized and return the writer singleton.
+This writer is sent to other systems to they can use the same log file.
+*/
+func GetLogWriter(workingDir string) (*io.PipeWriter, error) {
+	initLog(workingDir)
+	return logWriter, initError
+}
+
+func initLog(workingDir string) {
+	initBackend.Do(func() {
+		cfg, initError := config.GetConfig(workingDir)
+		if initError != nil {
+			return
+		}
+
+		filename := workingDir + "/logs/bitcoin/" + cfg.Network + "/lnd.log"
+		logWriter, _, initError = initLogRotator(filename, 10, 3)
+		if initError == nil {
+			logBackend = btclog.NewBackend(&Writer{logWriter})
+		}
+	})
+}
+
+func initLogRotator(logFile string, MaxLogFileSize int, MaxLogFiles int) (*io.PipeWriter, *rotator.Rotator, error) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create log directory: %v", err)
+	}
+	r, err := rotator.New(logFile, int64(MaxLogFileSize*1024), false, MaxLogFiles)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create file rotator: %v", err)
+	}
+
+	pr, pw := io.Pipe()
+	go r.Run(pr)
+
+	return pw, r, nil
+}

--- a/sync/init.go
+++ b/sync/init.go
@@ -1,27 +1,14 @@
 package sync
 
 import (
-	"os"
 	"sync"
 
 	"github.com/breez/breez/config"
+	"github.com/breez/breez/log"
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
 )
-
-func initJobLogger(workingDir, network string) (btclog.Logger, error) {
-	filename := workingDir + "/logs/bitcoin/" + network + "/lnd.log"
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	logger := btclog.NewBackend(f)
-	log := logger.Logger("SYNC")
-	log.SetLevel(btclog.LevelDebug)
-	return log, nil
-}
 
 /*
 Job contains a running job info.
@@ -47,11 +34,11 @@ func NewJob(workingDir string) (*Job, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	log, err := initJobLogger(workingDir, config.Network)
+	logBackend, err := log.GetLogBackend(workingDir)
 	if err != nil {
 		return nil, err
 	}
+	log := logBackend.Logger("SYNC")
 
 	return &Job{
 		log:        log,


### PR DESCRIPTION
This PR introduces a shared logging mechanism for breez and lightningLib. 
By shared I mean that breez implements the io.PipeWriter interface and provide it to lightningLib to be used there.
Besides the advantage of once central logging mechanism (same file, rotation, etc...) the control is now in breez which means the daemon doesn't have to be running in order for the logging to work. Instead logging is available immediately.