### PR TITLE
Persiste last filter

### DIFF
--- a/chainservice/init.go
+++ b/chainservice/init.go
@@ -52,6 +52,7 @@ func GetInstance(workingDir string) (*neutrino.ChainService, error) {
 		logger := logBackend.Logger("CHAIN")
 		logger.SetLevel(btclog.LevelDebug)
 		neutrino.UseLogger(logger)
+		neutrino.QueryTimeout = time.Second * 10
 	}
 	return chainService, err
 }

--- a/sync/db.go
+++ b/sync/db.go
@@ -1,0 +1,57 @@
+package sync
+
+import (
+	"encoding/binary"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	syncInfoBucket       = "syncInfo"
+	lastCFilterHeightKey = "lastCFilterHeight"
+)
+
+type jobDB struct {
+	db *bolt.DB
+}
+
+func openJobDB(path string) (*jobDB, error) {
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &jobDB{db: db}, nil
+}
+
+func (j *jobDB) close() error {
+	return j.db.Close()
+}
+
+func (j *jobDB) setCFilterSyncHeight(height uint64) error {
+	return j.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(syncInfoBucket))
+		if err != nil {
+			return err
+		}
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, height)
+		return bucket.Put([]byte(lastCFilterHeightKey), b)
+	})
+}
+
+func (j *jobDB) fetchCFilterSyncHeight() (uint64, error) {
+	var startSyncHeight uint64
+	err := j.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(syncInfoBucket))
+		if bucket == nil {
+			return nil
+		}
+		heightBytes := bucket.Get([]byte(lastCFilterHeightKey))
+		if heightBytes == nil {
+			return nil
+		}
+		startSyncHeight = binary.BigEndian.Uint64(heightBytes)
+		return nil
+	})
+	return startSyncHeight, err
+}


### PR DESCRIPTION
This PR is about letting the sync job write and fetch the last compact filter that was downloaded.
Now that neutrino is running in the background its `ChainTip` is progressing without downloading filters and we can't (it is wrong to) count on it a point to start the next download batch.
Instead we mark the height of the last filter that was downloaded and start from there.
In addition an adjustment to neutrino query timeout was done to 10 seconds.