### PR TITLE
Stop non-used neutrino

### DIFF
--- a/chainservice/init.go
+++ b/chainservice/init.go
@@ -69,11 +69,11 @@ func createService(workingDir string) (*neutrino.ChainService, error) {
 	if err != nil {
 		return nil, err
 	}
-	logBackend, err := log.GetLogBackend(workingDir)
-	if err != nil {
-		return nil, err
-	}
 	if logger == nil {
+		logBackend, err := log.GetLogBackend(workingDir)
+		if err != nil {
+			return nil, err
+		}
 		logger = logBackend.Logger("CHAIN")
 		logger.SetLevel(btclog.LevelDebug)
 		neutrino.UseLogger(logger)

--- a/sync/job.go
+++ b/sync/job.go
@@ -51,11 +51,12 @@ func (s *Job) terminated() bool {
 
 func (s *Job) syncFilters() (err error) {
 	s.log.Info("syncFilters started...")
-	chainService, err := chainservice.GetInstance(s.workingDir)
+	chainService, cleanFn, err := chainservice.NewService(s.workingDir)
 	if err != nil {
 		s.log.Errorf("Error creating ChainService: %s", err)
 		return err
 	}
+	defer cleanFn()
 	jobDB, err := openJobDB(path.Join(s.workingDir, "job.db"))
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR solves the problem where neutrino is kept alive when is not used by either the job or the breez daemon.
In order to makes things simpler at the high level parts (job, app) and remove the need for them to deal with synchronization code, the design here is to use reference count at the chainservice package.
Instead of a singleton pattern the callers now can retrieve the shared service but must call the cleanup function when they no longer use the service. 
At the chainservice package the reference count is maintained and if reaches zero the service is stopped.