### PR TITLE
Backup tests

### DIFF
--- a/backup/init.go
+++ b/backup/init.go
@@ -9,8 +9,18 @@ import (
 	"github.com/breez/lightninglib/daemon"
 )
 
+// ProviderFactory is a factory for create a specific provider.
+// This is the function needed to be implemented for a new provider
+// to be registered and used.
+type ProviderFactory func(authService AuthService) (Provider, error)
+
 var (
-	log = daemon.BackendLog().Logger("BCKP")
+	log              = daemon.BackendLog().Logger("BCKP")
+	providersFactory = map[string]ProviderFactory{
+		"gdrive": func(authService AuthService) (Provider, error) {
+			return NewGoogleDriveProvider(authService)
+		},
+	}
 )
 
 // Manager holds the data needed for the backup to execute its work.
@@ -53,11 +63,15 @@ func NewManager(
 	}, nil
 }
 
+// RegisterProvider registers a backup provider with a unique name
+func RegisterProvider(providerName string, factory ProviderFactory) {
+	providersFactory[providerName] = factory
+}
+
 func createBackupProvider(providerName string, authService AuthService) (Provider, error) {
-	switch providerName {
-	case "gdrive":
-		return NewGoogleDriveProvider(authService)
-	default:
+	factory, ok := providersFactory[providerName]
+	if !ok {
 		return nil, fmt.Errorf("provider not found for %v", providerName)
 	}
+	return factory(authService)
 }

--- a/backup/init.go
+++ b/backup/init.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"sync"
 
+	"github.com/breez/breez/config"
 	"github.com/breez/breez/data"
 	"github.com/breez/lightninglib/daemon"
 )
@@ -30,6 +31,8 @@ type Manager struct {
 	workingDir        string
 	db                *backupDB
 	provider          Provider
+	prepareBackupData DataPreparer
+	config            *config.Config
 	backupRequestChan chan struct{}
 	ntfnChan          chan data.NotificationEvent
 	quitChan          chan struct{}
@@ -41,6 +44,8 @@ func NewManager(
 	providerName string,
 	authService AuthService,
 	ntfnChan chan data.NotificationEvent,
+	prepareData DataPreparer,
+	config *config.Config,
 	workingDir string) (*Manager, error) {
 
 	provider, err := createBackupProvider(providerName, authService)
@@ -58,6 +63,8 @@ func NewManager(
 		workingDir:        workingDir,
 		ntfnChan:          ntfnChan,
 		provider:          provider,
+		prepareBackupData: prepareData,
+		config:            config,
 		backupRequestChan: make(chan struct{}, 10),
 		quitChan:          make(chan struct{}),
 	}, nil

--- a/backup/interface.go
+++ b/backup/interface.go
@@ -38,3 +38,7 @@ type ProviderError interface {
 type AuthService interface {
 	SignIn() (string, error)
 }
+
+// DataPreparer should be responsible to prepare the data needed to
+// be backed up. The data contains the file paths and the nodeID.
+type DataPreparer func() (paths []string, nodeID string, err error)

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -18,6 +18,10 @@ import (
 	"github.com/breez/lightninglib/lnrpc"
 )
 
+var (
+	backupDelay = time.Duration(time.Second * 2)
+)
+
 /*
 RequestBackup push a request for the backup files of breez
 */
@@ -34,7 +38,7 @@ func (b *Manager) RequestBackup() {
 
 	go func() {
 		select {
-		case <-time.After(time.Second * 2):
+		case <-time.After(backupDelay):
 		case <-b.quitChan:
 			return
 		}

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -12,10 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/breez/breez/config"
 	"github.com/breez/breez/data"
-	"github.com/breez/breez/db"
-	"github.com/breez/lightninglib/lnrpc"
 )
 
 var (
@@ -49,21 +45,17 @@ func (b *Manager) RequestBackup() {
 // Restore handles all the restoring process:
 // 1. Downloading the backed up files for a specific node id.
 // 2. Put the backed up files in the right place according to the configuration
-func (b *Manager) Restore(nodeID string) error {
+func (b *Manager) Restore(nodeID string) ([]string, error) {
 	backupID, err := b.getBackupIdentifier()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	files, err := b.provider.DownloadBackupFiles(nodeID, backupID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(files) != 3 {
-		return fmt.Errorf("wrong number of backup files %v", len(files))
-	}
-	c, err := config.GetConfig(b.workingDir)
-	if err != nil {
-		return err
+		return nil, fmt.Errorf("wrong number of backup files %v", len(files))
 	}
 
 	paths := map[string]string{
@@ -71,25 +63,27 @@ func (b *Manager) Restore(nodeID string) error {
 		"channel.db": "data/graph/{{network}}",
 		"breez.db":   "",
 	}
+	var targetFiles []string
 	for _, f := range files {
 		basename := path.Base(f)
 		p, ok := paths[basename]
 		if !ok {
-			return err
+			return nil, err
 		}
-		destDir := path.Join(b.workingDir, strings.Replace(p, "{{network}}", c.Network, -1))
+		destDir := path.Join(b.workingDir, strings.Replace(p, "{{network}}", b.config.Network, -1))
 		if destDir != b.workingDir {
 			err = os.MkdirAll(destDir, 0700)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 		err = os.Rename(f, path.Join(destDir, basename))
 		if err != nil {
-			return err
+			return nil, err
 		}
+		targetFiles = append(targetFiles, path.Join(destDir, basename))
 	}
-	return nil
+	return targetFiles, nil
 }
 
 // AvailableSnapshots returns a list of snsapshot that the backup provider reports
@@ -121,7 +115,7 @@ func (b *Manager) IsSafeToRunNode(nodeID string) (bool, error) {
 }
 
 // Start is the main go routine that listens to backup requests and is resopnsible for executing it.
-func (b *Manager) Start(lightningClient lnrpc.LightningClient, breezDB *db.DB) {
+func (b *Manager) Start() {
 	if atomic.SwapInt32(&b.started, 1) == 1 {
 		return
 	}
@@ -138,7 +132,7 @@ func (b *Manager) Start(lightningClient lnrpc.LightningClient, breezDB *db.DB) {
 					continue
 				}
 
-				paths, nodeID, err := b.prepareBackupInfo(lightningClient, breezDB)
+				paths, nodeID, err := b.prepareBackupData()
 				if err != nil {
 					log.Errorf("error in backup %v", err)
 					b.notifyBackupFailed(err)
@@ -167,9 +161,18 @@ func (b *Manager) Stop() {
 	if atomic.SwapInt32(&b.stopped, 1) == 1 {
 		return
 	}
-
+	b.db.close()
 	close(b.quitChan)
 	b.wg.Wait()
+}
+
+// destroy is intended to use internally for testing purpose.
+func (b *Manager) destroy() error {
+	b.Stop()
+	if err := os.RemoveAll(path.Join(b.workingDir, "backup")); err != nil {
+		return err
+	}
+	return os.Remove(path.Join(b.workingDir, "backup.db"))
 }
 
 func (b *Manager) notifyBackupFailed(err error) {
@@ -181,40 +184,6 @@ func (b *Manager) notifyBackupFailed(err error) {
 		}
 	}
 	b.ntfnChan <- data.NotificationEvent{Type: data.NotificationEvent_BACKUP_FAILED}
-}
-
-func (b *Manager) breezdbCopy(breezDB *db.DB) (string, error) {
-	dir, err := ioutil.TempDir("", "backup")
-	if err != nil {
-		return "", err
-	}
-	return breezDB.BackupDb(dir)
-}
-
-// extractBackupInfo extracts the information that is needed for the external backup service:
-// 1. paths - the files need to be backed up.
-// 2. nodeID - the current lightning node id.
-// 3. backupID - an identifier for this instance of breez. It is needed for conflict detection.
-func (b *Manager) prepareBackupInfo(lightningClient lnrpc.LightningClient, breezDB *db.DB) (paths []string, nodeID string, err error) {
-	log.Infof("extractBackupInfo started")
-	response, err := lightningClient.GetBackup(context.Background(), &lnrpc.GetBackupRequest{})
-	if err != nil {
-		log.Errorf("Couldn't get backup: %v", err)
-		return nil, "", err
-	}
-	info, err := lightningClient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
-	if err != nil {
-		return nil, "", err
-	}
-
-	f, err := b.breezdbCopy(breezDB)
-	if err != nil {
-		log.Errorf("Couldn't get breez backup file: %v", err)
-		return nil, "", err
-	}
-	files := append(response.Files, f)
-	log.Infof("extractBackupInfo completd")
-	return files, info.IdentityPubkey, nil
 }
 
 // getBackupIdentifier retrieves an identifier that is unique for this instance of breez.

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -1,0 +1,56 @@
+package backup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/breez/breez/data"
+)
+
+type MockAuthService struct{}
+
+func (s *MockAuthService) SignIn() (string, error) {
+	return "test-token", nil
+}
+
+type MockProvider struct {
+	UploadBackupFilesImpl   func(files []string, nodeID string) error
+	AvailableSnapshotsImpl  func() ([]SnapshotInfo, error)
+	DownloadBackupFilesImpl func(nodeID, backupID string) ([]string, error)
+}
+
+func newMockProvider() *MockProvider {
+	p := MockProvider{}
+	p.AvailableSnapshotsImpl = func() ([]SnapshotInfo, error) {
+		return []SnapshotInfo{}, nil
+	}
+	p.DownloadBackupFilesImpl = func(nodeID, backupID string) ([]string, error) {
+		return []string{}, nil
+	}
+	p.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+		return nil
+	}
+	return &p
+}
+
+func (m *MockProvider) UploadBackupFiles(files []string, nodeID string) error {
+	return m.UploadBackupFilesImpl(files, nodeID)
+}
+func (m *MockProvider) AvailableSnapshots() ([]SnapshotInfo, error) {
+	return m.AvailableSnapshotsImpl()
+}
+func (m *MockProvider) DownloadBackupFiles(nodeID, backupID string) ([]string, error) {
+	return m.DownloadBackupFilesImpl(nodeID, backupID)
+}
+
+func TestCreateDefaultProvider(t *testing.T) {
+	tempDir := os.TempDir()
+	ntfnChan := make(chan data.NotificationEvent)
+	manager, err := NewManager("gdrive", nil, ntfnChan, tempDir)
+	if err != nil {
+		t.Error(err)
+	}
+	if _, ok := manager.provider.(*GoogleDriveProvider); !ok {
+		t.Error("default provider is not google drive")
+	}
+}

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -1,9 +1,14 @@
 package backup
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"path"
 	"testing"
+	"time"
 
+	"github.com/breez/breez/config"
 	"github.com/breez/breez/data"
 )
 
@@ -13,44 +18,297 @@ func (s *MockAuthService) SignIn() (string, error) {
 	return "test-token", nil
 }
 
-type MockProvider struct {
+type MockTester struct {
+	uploadCounter           int
+	downloadCounter         int
+	preparer                DataPreparer
+	lastNotification        data.NotificationEvent
 	UploadBackupFilesImpl   func(files []string, nodeID string) error
 	AvailableSnapshotsImpl  func() ([]SnapshotInfo, error)
 	DownloadBackupFilesImpl func(nodeID, backupID string) ([]string, error)
 }
 
-func newMockProvider() *MockProvider {
-	p := MockProvider{}
+func newDefaultMockTester() *MockTester {
+	p := MockTester{}
+	p.preparer = func() (paths []string, nodeID string, err error) {
+		return []string{"file1"}, "test-node-id", nil
+	}
 	p.AvailableSnapshotsImpl = func() ([]SnapshotInfo, error) {
 		return []SnapshotInfo{}, nil
 	}
 	p.DownloadBackupFilesImpl = func(nodeID, backupID string) ([]string, error) {
+		p.downloadCounter++
 		return []string{}, nil
 	}
 	p.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+		time.Sleep(time.Millisecond * 10)
+		p.uploadCounter++
 		return nil
 	}
 	return &p
 }
 
-func (m *MockProvider) UploadBackupFiles(files []string, nodeID string) error {
+func (m *MockTester) UploadBackupFiles(files []string, nodeID string) error {
 	return m.UploadBackupFilesImpl(files, nodeID)
 }
-func (m *MockProvider) AvailableSnapshots() ([]SnapshotInfo, error) {
+func (m *MockTester) AvailableSnapshots() ([]SnapshotInfo, error) {
 	return m.AvailableSnapshotsImpl()
 }
-func (m *MockProvider) DownloadBackupFiles(nodeID, backupID string) ([]string, error) {
+func (m *MockTester) DownloadBackupFiles(nodeID, backupID string) ([]string, error) {
 	return m.DownloadBackupFilesImpl(nodeID, backupID)
+}
+
+func prepareBackupData() (paths []string, nodeID string, err error) {
+	return []string{"file1"}, "test-node-id", nil
+}
+
+func createTestManager(mp *MockTester) (manager *Manager, err error) {
+	backupDelay = time.Duration(0)
+	RegisterProvider("mock", func(authServie AuthService) (Provider, error) { return mp, nil })
+
+	ntfnChan := make(chan data.NotificationEvent)
+	dir := os.TempDir()
+	fmt.Println("tempDir " + dir)
+
+	config := &config.Config{
+		Network: "mainnet",
+	}
+	manager, err = NewManager("mock", nil, ntfnChan, mp.preparer, config, dir)
+	if err != nil {
+		return
+	}
+	go func() {
+		for {
+			select {
+			case msg := <-ntfnChan:
+				mp.lastNotification = msg
+			case <-manager.quitChan:
+				close(ntfnChan)
+				os.RemoveAll(path.Join(dir, "backup.db"))
+				fmt.Println("Remove db from go routine")
+				return
+			}
+		}
+	}()
+	return
+}
+
+type mockAuthError struct{}
+
+func (me *mockAuthError) Error() string {
+	return ""
+}
+func (me *mockAuthError) IsAuthError() bool {
+	return true
 }
 
 func TestCreateDefaultProvider(t *testing.T) {
 	tempDir := os.TempDir()
+	fmt.Println("tempDir " + tempDir)
 	ntfnChan := make(chan data.NotificationEvent)
-	manager, err := NewManager("gdrive", nil, ntfnChan, tempDir)
-	if err != nil {
-		t.Error(err)
+	config := &config.Config{
+		Network: "mainnet",
 	}
+	manager, err := NewManager("gdrive", nil, ntfnChan, prepareBackupData, config, tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.destroy()
+
 	if _, ok := manager.provider.(*GoogleDriveProvider); !ok {
 		t.Error("default provider is not google drive")
+	}
+}
+
+func TestRequestBackup(t *testing.T) {
+	tester := newDefaultMockTester()
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Start()
+	defer manager.destroy()
+
+	manager.RequestBackup()
+	time.Sleep(100 * time.Millisecond)
+	if tester.uploadCounter != 1 {
+		t.Error("Backup was not called after backup requested")
+	}
+}
+
+func TestMultipleRequestBackup(t *testing.T) {
+	tester := newDefaultMockTester()
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Start()
+	defer manager.destroy()
+
+	for i := 0; i < 10; i++ {
+		manager.RequestBackup()
+	}
+	time.Sleep(100 * time.Millisecond)
+	if tester.uploadCounter > 2 {
+		t.Error("Backup was called too much times")
+	}
+}
+
+func TestErrorInPrepareBackup(t *testing.T) {
+	preparer := func() (paths []string, nodeID string, err error) {
+		return nil, "", errors.New("failed to prepare")
+	}
+	tester := newDefaultMockTester()
+	tester.preparer = preparer
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Start()
+	defer manager.destroy()
+
+	manager.RequestBackup()
+	time.Sleep(100 * time.Millisecond)
+	if tester.uploadCounter > 0 {
+		t.Error("Backup was called despite error in preparing the data")
+	}
+}
+
+func TestErrorInUpload(t *testing.T) {
+	tester := newDefaultMockTester()
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+		return errors.New("failed to upload files")
+	}
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Start()
+	defer manager.destroy()
+
+	manager.RequestBackup()
+	time.Sleep(100 * time.Millisecond)
+	if tester.uploadCounter > 0 {
+		t.Error("Backup was called despite error in preparing the data")
+	}
+	if tester.lastNotification.Type != data.NotificationEvent_BACKUP_FAILED {
+		t.Error("wrong fail notification type")
+	}
+}
+
+func TestAuthError(t *testing.T) {
+	tester := newDefaultMockTester()
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+		return &mockAuthError{}
+	}
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.Start()
+	defer manager.destroy()
+
+	manager.RequestBackup()
+	time.Sleep(100 * time.Millisecond)
+	if tester.uploadCounter > 0 {
+		t.Error("Backup was called despite error in preparing the data")
+	}
+	if tester.lastNotification.Type != data.NotificationEvent_BACKUP_AUTH_FAILED {
+		t.Error("wrong fail notification type")
+	}
+}
+
+func TestRestoreWrongNumberOfFiles(t *testing.T) {
+	tester := newDefaultMockTester()
+
+	tester.DownloadBackupFilesImpl = func(nodeID, backupID string) ([]string, error) {
+		return []string{"file1"}, nil
+	}
+
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.destroy()
+
+	if _, err := manager.Restore("test-node-id"); err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRestoreSuccess(t *testing.T) {
+	tester := newDefaultMockTester()
+	dir := os.TempDir()
+
+	downloads := []string{"wallet.db", "channel.db", "breez.db"}
+	sourceFiles := []string{}
+	for _, d := range downloads {
+		sourceFiles = append(sourceFiles, path.Join(dir, d))
+	}
+
+	tester.DownloadBackupFilesImpl = func(nodeID, backupID string) ([]string, error) {
+		if nodeID != "test-node-id" {
+			return nil, errors.New("node id not found")
+		}
+
+		for _, d := range sourceFiles {
+			_, err := os.Create(d)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return sourceFiles, nil
+	}
+
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.destroy()
+
+	restoredFiles, err := manager.Restore("test-node-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		for _, f := range sourceFiles {
+			os.Remove(f)
+		}
+		for _, f := range restoredFiles {
+			os.Remove(f)
+		}
+	}()
+
+	for _, f := range restoredFiles {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			t.Fatalf("file was not restored to the right location %v", f)
+		}
+	}
+}
+
+func TestBackupConflict(t *testing.T) {
+	tester := newDefaultMockTester()
+
+	tester.AvailableSnapshotsImpl = func() ([]SnapshotInfo, error) {
+		return []SnapshotInfo{
+			SnapshotInfo{
+				NodeID:       "test-node-id",
+				BackupID:     "conflict-backup-id",
+				ModifiedTime: time.Now().String(),
+			},
+		}, nil
+	}
+
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.destroy()
+
+	safe, err := manager.IsSafeToRunNode("test-node-id")
+	if safe {
+		t.Fatal("returned safe to run even though it isn't")
 	}
 }

--- a/init.go
+++ b/init.go
@@ -231,6 +231,8 @@ func Init(workingDir string, services AppServices) (err error) {
 		bProviderName,
 		&AuthService{appServices: appServices},
 		notificationsChan,
+		prepareBackupInfo,
+		cfg,
 		appWorkingDir,
 	)
 	if err != nil {
@@ -337,7 +339,7 @@ func stopLightningDaemon() {
 
 func startBreez() {
 	//start the go routings
-	backupManager.Start(lightningClient, breezDB)
+	backupManager.Start()
 	if !ensureSafeToRunNode() {
 		return
 	}


### PR DESCRIPTION
In this PR we add unit tests for the backup package.
The formal coverage is 42% but given the fact that half of the code is the actual google drive implementation (this is not tested), the infrastructure itself is over 90% covered.
In order to add these tests several changes needed to be done in the package so the code will be more testable.
The biggest change was to move the prepareData implementation out of the package and use a small function interface instead. This way we could mock it on testing and reduce the dependencies in the backup package itself that is now no longer depends on breez and breezdb packages.