### PR TITLE
ctp: Fix memo marshaling.

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -301,15 +301,6 @@ func AddInvoice(invoice []byte) (paymentRequest string, err error) {
 }
 
 /*
-AddStandardInvoice is part of the binding inteface which is delegated to breez.AddStandardInvoice
-*/
-func AddStandardInvoice(invoice []byte) (paymentRequest string, err error) {
-	decodedStandardInvoiceMemo := &data.InvoiceMemo{}
-	proto.Unmarshal(invoice, decodedStandardInvoiceMemo)
-	return breez.AddStandardInvoice(decodedStandardInvoiceMemo)
-}
-
-/*
 DecodePaymentRequest is part of the binding inteface which is delegated to breez.DecodePaymentRequest
 */
 func DecodePaymentRequest(paymentRequest string) ([]byte, error) {

--- a/payments.go
+++ b/payments.go
@@ -118,15 +118,7 @@ AddInvoice encapsulate a given amount and description in a payment request
 */
 func AddInvoice(invoice *data.InvoiceMemo) (paymentRequest string, err error) {
 	// Format the standard invoice memo
-	memo := invoice.Description
-	formatPayeeData := invoice.PayeeName != "" && invoice.PayeeImageURL != ""
-	if formatPayeeData {
-		memo += (" | " + invoice.PayeeName + " | " + invoice.PayeeImageURL)
-		formatPayerData := invoice.PayerName != "" && invoice.PayerImageURL != ""
-		if formatPayerData {
-			memo += (" | " + invoice.PayerName + " | " + invoice.PayerImageURL)
-		}
-	}
+	memo := formatTextMemo(invoice)
 
 	if invoice.Expiry <= 0 {
 		invoice.Expiry = defaultInvoiceExpiry

--- a/payments.go
+++ b/payments.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	defaultInvoiceExpiry       int64 = 3600
-	invoiceCustomPartDelimiter       = "|\n"
+	invoiceCustomPartDelimiter       = " |\n"
 )
 
 var blankInvoiceGroup singleflight.Group

--- a/payments_test.go
+++ b/payments_test.go
@@ -1,0 +1,71 @@
+package breez
+
+import (
+	"testing"
+
+	"github.com/breez/breez/data"
+)
+
+func TestOnlyDescription(t *testing.T) {
+	invoiceMemo := &data.InvoiceMemo{
+		Description: "test",
+	}
+	description := formatTextMemo(invoiceMemo)
+	if description != "test" {
+		t.Fatalf("description should be test, instead got %v", description)
+	}
+
+	invoiceMemo = &data.InvoiceMemo{}
+	parseTextMemo(description, invoiceMemo)
+	if invoiceMemo.Description != "test" {
+		t.Fatalf("invoiceMemo.Description should be test, instead got %v", invoiceMemo.Description)
+	}
+}
+
+func TestWithPayeeData(t *testing.T) {
+	invoiceMemo := &data.InvoiceMemo{
+		Description:   "test",
+		PayeeName:     "payee",
+		PayeeImageURL: "payee_image",
+	}
+	description := formatTextMemo(invoiceMemo)
+	invoiceMemo = &data.InvoiceMemo{}
+	parseTextMemo(description, invoiceMemo)
+	if invoiceMemo.Description != "test" {
+		t.Fatalf("invoiceMemo.Description should be test, instead got %v", invoiceMemo.Description)
+	}
+	if invoiceMemo.PayeeName != "payee" {
+		t.Fatalf("invoiceMemo.PayeeName should be payee, instead got %v", invoiceMemo.PayeeName)
+	}
+	if invoiceMemo.PayeeImageURL != "payee_image" {
+		t.Fatalf("invoiceMemo.PayeeImageURL should be payee_image, instead got %v", invoiceMemo.PayeeImageURL)
+	}
+}
+
+func TestWithFullCustomData(t *testing.T) {
+	invoiceMemo := &data.InvoiceMemo{
+		Description:   "test",
+		PayeeName:     "payee",
+		PayeeImageURL: "payee_image",
+		PayerName:     "payer",
+		PayerImageURL: "payer_image",
+	}
+	description := formatTextMemo(invoiceMemo)
+	invoiceMemo = &data.InvoiceMemo{}
+	parseTextMemo(description, invoiceMemo)
+	if invoiceMemo.Description != "test" {
+		t.Fatalf("invoiceMemo.Description should be test, instead got %v", invoiceMemo.Description)
+	}
+	if invoiceMemo.PayeeName != "payee" {
+		t.Fatalf("invoiceMemo.PayeeName should be payee, instead got %v", invoiceMemo.PayeeName)
+	}
+	if invoiceMemo.PayeeImageURL != "payee_image" {
+		t.Fatalf("invoiceMemo.PayeeImageURL should be payee_image, instead got %v", invoiceMemo.PayeeImageURL)
+	}
+	if invoiceMemo.PayerName != "payer" {
+		t.Fatalf("invoiceMemo.PayerName should be payer, instead got %v", invoiceMemo.PayerName)
+	}
+	if invoiceMemo.PayerImageURL != "payer_image" {
+		t.Fatalf("invoiceMemo.PayerImageURL should be payer_image, instead got %v", invoiceMemo.PayerImageURL)
+	}
+}


### PR DESCRIPTION
This PR ensures the serialized memo is marshaled to hex before we put it into the payment request instead of just creating string from bytes.
It also ensured the un-marshaling works the same.