### PR TITLE
connect: retry connect to node before got channel.

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -116,6 +116,13 @@ func onRoutingNodeConnectionChanged(connected bool) {
 		go ensureSafeToRunNode()
 	} else {
 		nodeOnlineNotifier.setOffline()
+
+		// in case we don't have a channel yet, we will try to connect
+		// again so we can keep trying to get an opened channel.
+		_, channels, _ := getBreezOpenChannels()
+		if len(channels) == 0 {
+			connectRoutingNode()
+		}
 	}
 }
 


### PR DESCRIPTION
In this PR we make sure the client keeps trying to connect to routing node in case we still don' t have an opened channel.
Before this commit, if from some reason we got a disconnect event after the initial connection and before the channel was opened, no further attempts were done to connect to the routing node.
This logic is required only when no  channel was opened since in case a channel exists it is handled automatically by lightning lib.