### PR TITLE
channelswatcher: ignore empty channels.

### DIFF
--- a/sync/channelswatcher.go
+++ b/sync/channelswatcher.go
@@ -51,6 +51,11 @@ func NewChannelsWatcher(
 	var firstChannelBlockHeight uint64
 
 	for _, c := range channels {
+		if c.LocalCommitment.LocalBalance == 0 {
+			log.Infof("Skipping watching channel with zero balance: %v", c.ShortChannelID.String())
+			continue
+		}
+
 		fundingOut := c.FundingOutpoint
 		localKey := c.LocalChanCfg.MultiSigKey.PubKey.SerializeCompressed()
 		remoteKey := c.RemoteChanCfg.MultiSigKey.PubKey.SerializeCompressed()


### PR DESCRIPTION
In this PR we skip watching channels with zero local balance.
The main goal is to prevent sending warning notification to the user in that case such channels
is closed while he is offline as it doesn't really affect any of his funds.