### PR TITLE
Cache last synced header timestamp

### DIFF
--- a/app.go
+++ b/app.go
@@ -203,3 +203,7 @@ func (a *App) SetPeers(peers []string) error {
 func (a *App) GetPeers() (peers []string, isDefault bool, err error) {
 	return a.breezDB.GetPeers(a.cfg.JobCfg.ConnectedPeers)
 }
+
+func (a *App) LastSyncedHeaderTimestamp() (int64, error) {
+	return a.breezDB.FetchLastSyncedHeaderTimestamp()
+}

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -186,7 +186,7 @@ func RestoreBackup(nodeID string) (err error) {
 /*
 AvailableSnapshots is part of the binding inteface which is delegated to breez.AvailableSnapshots
 */
-func AvailableSnapshots(nodeID string) (string, error) {
+func AvailableSnapshots() (string, error) {
 	snapshots, err := breezApp.BackupManager.AvailableSnapshots()
 	if err != nil {
 		return "", err

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -113,6 +113,13 @@ func Start() error {
 }
 
 /*
+LastSyncedHeaderTimestamp returns the last header the node is synced to.
+*/
+func LastSyncedHeaderTimestamp() (int64, error) {
+	return breezApp.LastSyncedHeaderTimestamp();
+}
+
+/*
 RestartDaemon attempts to restart the daemon service.
 */
 func RestartDaemon() error {

--- a/db/db.go
+++ b/db/db.go
@@ -32,6 +32,9 @@ const (
 
 	//Network configuration
 	networkBucket = "network"
+
+	//syncstatus
+	syncstatus = "syncstatus"
 )
 
 var (
@@ -117,6 +120,11 @@ func openDB(dbPath string) (*DB, error) {
 		}
 
 		_, err = tx.CreateBucketIfNotExists([]byte(networkBucket))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists([]byte(syncstatus))
 		if err != nil {
 			return err
 		}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -122,3 +122,27 @@ func TestAccount(t *testing.T) {
 		t.Error("account should be nil")
 	}
 }
+
+func TestSync(t *testing.T) {
+	var err error
+	db, err := openDB("testdb")
+	defer db.DeleteDB()
+	lastTS, err := db.FetchLastSyncedHeaderTimestamp()
+	if err != nil {
+		t.Error("failed to fetch header timestamp", err)
+	}
+	if lastTS != 0 {
+		t.Error("First timestamp should be zero.")
+	}
+	err = db.SetLastSyncedHeaderTimestamp(100)
+	if err != nil {
+		t.Error("Failed to set last header timestamp.")
+	} 
+	lastTS, err = db.FetchLastSyncedHeaderTimestamp()
+	if err != nil {
+		t.Error("failed to fetch header timestamp", err)
+	}
+	if lastTS != 100 {
+		t.Error("Timestamp should be 100.")
+	}
+}

--- a/db/syncstatus.go
+++ b/db/syncstatus.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	
+)
+
+// FetchLastSyncedHeaderTimestamp the last known header timestamp that the node is synced to.
+func (db *DB) FetchLastSyncedHeaderTimestamp() (int64, error) {
+	tsBytes, err := db.fetchItem([]byte(syncstatus), []byte("last_header_timestamp"))
+	if err != nil || tsBytes == nil {
+		return 0, err
+	}
+	return int64(btoi(tsBytes)), nil
+}
+
+// SetLastSyncedHeaderTimestamp saves the last known header timestamp that the node is synced to.
+func (db *DB) SetLastSyncedHeaderTimestamp(ts int64) error {
+	return db.saveItem([]byte(syncstatus), []byte("last_header_timestamp"), itob(uint64(ts)))
+}

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,6 @@ github.com/lightninglabs/neutrino v0.0.0-20181102193151-641af1ca5561 h1:Xi58PB1h
 github.com/lightninglabs/neutrino v0.0.0-20181102193151-641af1ca5561/go.mod h1:KJq43Fu9ceitbJsSXMILcT4mGDNI/crKmPIkDOZXFyM=
 github.com/lightningnetwork/lightning-onion v0.0.0-20180605012408-ac4d9da8f1d6 h1:ONLGrYJVQdbtP6CE/ff1KNWZtygRGEh12RzonTiCzPs=
 github.com/lightningnetwork/lightning-onion v0.0.0-20180605012408-ac4d9da8f1d6/go.mod h1:8EgEt4a/NUOVQd+3kk6n9aZCJ1Ssj96Pb6lCrci+6oc=
-github.com/lightningnetwork/lnd/queue v1.0.0 h1:eVUxXIzLm1IdLC5eGzs2z3NzgLYRapy44KCvsDZQ/HI=
-github.com/lightningnetwork/lnd/queue v1.0.0/go.mod h1:vaQwexir73flPW43Mrm7JOgJHmcEFBWWSl9HlyASoms=
 github.com/lightningnetwork/lnd/ticker v1.0.0 h1:S1b60TEGoTtCe2A0yeB+ecoj/kkS4qpwh6l+AkQEZwU=
 github.com/lightningnetwork/lnd/ticker v1.0.0/go.mod h1:iaLXJiVgI1sPANIF2qYYUJXjoksPNvGNYowB8aRbpX0=
 github.com/ltcsuite/ltcd v0.0.0-20170901085657-5f654d5faab9 h1:aLgtHOvaE6DjIKS5IpQU6ZLjdcQzjxHTMPOpq4pAY+M=

--- a/lnnode/notifier.go
+++ b/lnnode/notifier.go
@@ -212,6 +212,11 @@ func (d *Daemon) syncToChain(ctx context.Context) error {
 		}
 
 		d.log.Infof("Sync to chain interval Synced=%v BlockHeight=%v", chainInfo.SyncedToChain, chainInfo.BlockHeight)
+		
+		if err := d.breezDB.SetLastSyncedHeaderTimestamp(chainInfo.BestHeaderTimestamp); err != nil {
+			d.log.Errorf("Failed to set last header timestamp")
+		}
+		
 		if chainInfo.SyncedToChain {
 			d.log.Infof("Synchronized to chain finshed BlockHeight=%v", chainInfo.BlockHeight)
 			break


### PR DESCRIPTION
This PR caches the last synced header timestamp after every sync, whether it is from the background job worker or from the main app.
This header is used later to know in a quick way how much the node is far from full sync and as a result whether to show a blocking sync ui on start.