### PR TITLE
Allow use security key to encrypt backup files.

### DIFF
--- a/app.go
+++ b/app.go
@@ -99,7 +99,7 @@ func (a *App) RestartDaemon() error {
 
 // Restore is the breez API for restoring a specific nodeID using the configured
 // backup backend provider.
-func (a *App) Restore(nodeID string) error {
+func (a *App) Restore(nodeID string, key string) error {
 	a.log.Infof("Restore nodeID = %v", nodeID)
 	if err := a.releaseBreezDB(); err != nil {
 		return err
@@ -107,7 +107,7 @@ func (a *App) Restore(nodeID string) error {
 	defer func() {
 		a.breezDB, a.releaseBreezDB, _ = db.Get(a.cfg.WorkingDir)
 	}()
-	_, err := a.BackupManager.Restore(nodeID)
+	_, err := a.BackupManager.Restore(nodeID, key)
 	return err
 }
 

--- a/app_init.go
+++ b/app_init.go
@@ -123,6 +123,7 @@ func NewApp(workingDir string, applicationServices AppServices) (*App, error) {
 		app.onServiceEvent,
 		app.prepareBackupInfo,
 		app.cfg,
+		logBackend.Logger("BCKP"),
 	)
 	if err != nil {
 		return nil, err

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -1,0 +1,80 @@
+package backup
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"	
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func encryptFile(source, dest string, key []byte) error {
+	fileContent, err := ioutil.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+
+	nonce := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	encryptedContent := aesgcm.Seal(nonce, nonce, fileContent, nil)
+
+	if err = ioutil.WriteFile(dest, encryptedContent, os.ModePerm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func decryptFile(source, dest string, key []byte) error {
+	fileContent, err := ioutil.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	nonceSize := aesgcm.NonceSize()
+	nonce, cipherContent := fileContent[:nonceSize], fileContent[nonceSize:]
+
+	decryptedContent, err := aesgcm.Open(nil, nonce, cipherContent, nil)
+	if err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(dest, decryptedContent, os.ModePerm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateEncryptionKey(pin string) []byte {
+	if pin == "" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(pin))
+	return sum[:]
+}

--- a/backup/init.go
+++ b/backup/init.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/breez/breez/config"
 	"github.com/breez/breez/data"
-	breezlog "github.com/breez/breez/log"
 	"github.com/btcsuite/btclog"
 )
 
@@ -37,6 +36,7 @@ type Manager struct {
 	onServiceEvent    func(event data.NotificationEvent)
 	quitChan          chan struct{}
 	log               btclog.Logger
+	encryptionKey     []byte
 	wg                sync.WaitGroup
 }
 
@@ -46,13 +46,8 @@ func NewManager(
 	authService AuthService,
 	onServiceEvent func(event data.NotificationEvent),
 	prepareData DataPreparer,
-	config *config.Config) (*Manager, error) {
-
-	logBackend, err := breezlog.GetLogBackend(config.WorkingDir)
-	if err != nil {
-		return nil, err
-	}
-	log := logBackend.Logger("BCKP")
+	config *config.Config,
+	log btclog.Logger) (*Manager, error) {
 
 	provider, err := createBackupProvider(providerName, authService, log)
 	if err != nil {

--- a/backup/init.go
+++ b/backup/init.go
@@ -37,6 +37,7 @@ type Manager struct {
 	quitChan          chan struct{}
 	log               btclog.Logger
 	encryptionKey     []byte
+	mu                sync.Mutex
 	wg                sync.WaitGroup
 }
 

--- a/backup/interface.go
+++ b/backup/interface.go
@@ -4,6 +4,7 @@ package backup
 type SnapshotInfo struct {
 	NodeID       string
 	BackupID     string
+	Encrypted    bool
 	ModifiedTime string
 }
 
@@ -18,7 +19,7 @@ type Service interface {
 // Provider represents the functionality needed to be implemented for any backend backup
 // storage provider. This provider will be used and inststiated by the service.
 type Provider interface {
-	UploadBackupFiles(files []string, nodeID string) error
+	UploadBackupFiles(files []string, nodeID string, encrypted bool) error
 	AvailableSnapshots() ([]SnapshotInfo, error)
 	DownloadBackupFiles(nodeID, backupID string) ([]string, error)
 }

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -78,7 +78,7 @@ func createTestManager(mp *MockTester) (manager *Manager, err error) {
 	onEvent := func(d data.NotificationEvent) {
 		ntfnChan <- d
 	}
-	manager, err = NewManager("mock", nil, onEvent, mp.preparer, config)
+	manager, err = NewManager("mock", nil, onEvent, mp.preparer, config, btclog.Disabled)
 	if err != nil {
 		return
 	}
@@ -117,7 +117,7 @@ func TestCreateDefaultProvider(t *testing.T) {
 	onEvent := func(d data.NotificationEvent) {
 		ntfnChan <- d
 	}
-	manager, err := NewManager("gdrive", nil, onEvent, prepareBackupData, config)
+	manager, err := NewManager("gdrive", nil, onEvent, prepareBackupData, config, btclog.Disabled)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestRequestBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start()
+	manager.Start("")
 	defer manager.destroy()
 
 	manager.RequestBackup()
@@ -150,7 +150,7 @@ func TestMultipleRequestBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start()
+	manager.Start("")
 	defer manager.destroy()
 
 	for i := 0; i < 10; i++ {
@@ -172,7 +172,7 @@ func TestErrorInPrepareBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start()
+	manager.Start("")
 	defer manager.destroy()
 
 	manager.RequestBackup()
@@ -191,7 +191,7 @@ func TestErrorInUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start()
+	manager.Start("")
 	defer manager.destroy()
 
 	manager.RequestBackup()
@@ -213,7 +213,7 @@ func TestAuthError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start()
+	manager.Start("")
 	defer manager.destroy()
 
 	manager.RequestBackup()

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -1,8 +1,10 @@
 package backup
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -24,9 +26,10 @@ type MockTester struct {
 	downloadCounter         int
 	preparer                DataPreparer
 	lastNotification        data.NotificationEvent
-	UploadBackupFilesImpl   func(files []string, nodeID string) error
+	UploadBackupFilesImpl   func(files []string, nodeID string, encrypted bool) error
 	AvailableSnapshotsImpl  func() ([]SnapshotInfo, error)
 	DownloadBackupFilesImpl func(nodeID, backupID string) ([]string, error)
+	MsgChannel              chan data.NotificationEvent
 }
 
 func newDefaultMockTester() *MockTester {
@@ -41,16 +44,17 @@ func newDefaultMockTester() *MockTester {
 		p.downloadCounter++
 		return []string{}, nil
 	}
-	p.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+	p.UploadBackupFilesImpl = func(files []string, nodeID string, encrypted bool) error {
 		time.Sleep(time.Millisecond * 10)
 		p.uploadCounter++
 		return nil
 	}
+	p.MsgChannel = make(chan data.NotificationEvent, 100)
 	return &p
 }
 
-func (m *MockTester) UploadBackupFiles(files []string, nodeID string) error {
-	return m.UploadBackupFilesImpl(files, nodeID)
+func (m *MockTester) UploadBackupFiles(files []string, nodeID string, encrypted bool) error {
+	return m.UploadBackupFilesImpl(files, nodeID, false)
 }
 func (m *MockTester) AvailableSnapshots() ([]SnapshotInfo, error) {
 	return m.AvailableSnapshotsImpl()
@@ -67,7 +71,7 @@ func createTestManager(mp *MockTester) (manager *Manager, err error) {
 	backupDelay = time.Duration(0)
 	RegisterProvider("mock", func(authServie AuthService, logger btclog.Logger) (Provider, error) { return mp, nil })
 
-	ntfnChan := make(chan data.NotificationEvent)
+	ntfnChan := make(chan data.NotificationEvent, 100)
 	dir := os.TempDir()
 	fmt.Println("tempDir " + dir)
 
@@ -87,8 +91,8 @@ func createTestManager(mp *MockTester) (manager *Manager, err error) {
 			select {
 			case msg := <-ntfnChan:
 				mp.lastNotification = msg
+				mp.MsgChannel <- msg
 			case <-manager.quitChan:
-				close(ntfnChan)
 				os.RemoveAll(path.Join(dir, "backup.db"))
 				fmt.Println("Remove db from go routine")
 				return
@@ -134,11 +138,11 @@ func TestRequestBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start("")
+	manager.Start()
 	defer manager.destroy()
 
 	manager.RequestBackup()
-	time.Sleep(100 * time.Millisecond)
+	waitForBackupEnd(tester.MsgChannel)
 	if tester.uploadCounter != 1 {
 		t.Error("Backup was not called after backup requested")
 	}
@@ -150,7 +154,7 @@ func TestMultipleRequestBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start("")
+	manager.Start()
 	defer manager.destroy()
 
 	for i := 0; i < 10; i++ {
@@ -172,11 +176,11 @@ func TestErrorInPrepareBackup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start("")
+	manager.Start()
 	defer manager.destroy()
 
 	manager.RequestBackup()
-	time.Sleep(100 * time.Millisecond)
+	waitForBackupEnd(tester.MsgChannel)
 	if tester.uploadCounter > 0 {
 		t.Error("Backup was called despite error in preparing the data")
 	}
@@ -184,18 +188,18 @@ func TestErrorInPrepareBackup(t *testing.T) {
 
 func TestErrorInUpload(t *testing.T) {
 	tester := newDefaultMockTester()
-	tester.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encrypted bool) error {
 		return errors.New("failed to upload files")
 	}
 	manager, err := createTestManager(tester)
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start("")
+	manager.Start()
 	defer manager.destroy()
 
 	manager.RequestBackup()
-	time.Sleep(100 * time.Millisecond)
+	waitForBackupEnd(tester.MsgChannel)
 	if tester.uploadCounter > 0 {
 		t.Error("Backup was called despite error in preparing the data")
 	}
@@ -206,18 +210,18 @@ func TestErrorInUpload(t *testing.T) {
 
 func TestAuthError(t *testing.T) {
 	tester := newDefaultMockTester()
-	tester.UploadBackupFilesImpl = func(files []string, nodeID string) error {
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encrypted bool) error {
 		return &mockAuthError{}
 	}
 	manager, err := createTestManager(tester)
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.Start("")
+	manager.Start()
 	defer manager.destroy()
 
 	manager.RequestBackup()
-	time.Sleep(100 * time.Millisecond)
+	waitForBackupEnd(tester.MsgChannel)
 	if tester.uploadCounter > 0 {
 		t.Error("Backup was called despite error in preparing the data")
 	}
@@ -239,7 +243,7 @@ func TestRestoreWrongNumberOfFiles(t *testing.T) {
 	}
 	defer manager.destroy()
 
-	if _, err := manager.Restore("test-node-id"); err == nil {
+	if _, err := manager.Restore("test-node-id", ""); err == nil {
 		t.Fatal(err)
 	}
 }
@@ -275,7 +279,7 @@ func TestRestoreSuccess(t *testing.T) {
 	}
 	defer manager.destroy()
 
-	restoredFiles, err := manager.Restore("test-node-id")
+	restoredFiles, err := manager.Restore("test-node-id", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,5 +322,105 @@ func TestBackupConflict(t *testing.T) {
 	safe, err := manager.IsSafeToRunNode("test-node-id")
 	if safe {
 		t.Fatal("returned safe to run even though it isn't")
+	}
+}
+
+func TestEncryptDecryptFiles(t *testing.T) {
+	key := generateEncryptionKey("123456")
+	originalContent := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	dir := os.TempDir()
+	file := path.Join(dir, "sourceFile")
+	encryptedFile := path.Join(dir, "encryptedFile")
+	decryptedFile := path.Join(dir, "decryptedFile")
+	if err := ioutil.WriteFile(file, originalContent, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := encryptFile(file, encryptedFile, key); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := decryptFile(encryptedFile, decryptedFile, key); err != nil {
+		t.Fatal(err)
+	}
+	content, err := ioutil.ReadFile(decryptedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(content, originalContent) != 0 {
+		t.Error("Failed to decrypt file", content)
+	}
+}
+
+func TestEncryptedBackup(t *testing.T) {
+	securityPIN := "123456"
+	originalContent := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	dir := os.TempDir()
+	downloads := []string{
+		path.Join(dir, "wallet.db"),
+		path.Join(dir, "channel.db"),
+		path.Join(dir, "breez.db"),
+	}
+	defer func() {
+		for _, backupFile := range downloads {
+			os.Remove(backupFile)
+		}
+	}()
+
+	preparer := func() (paths []string, nodeID string, err error) {
+		for _, backupFile := range downloads {
+			if err := ioutil.WriteFile(backupFile, originalContent, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return downloads, "test-node-id", nil
+	}
+	tester := newDefaultMockTester()
+	tester.preparer = preparer
+	tester.DownloadBackupFilesImpl = func(nodeID, backupID string) ([]string, error) {
+		time.Sleep(100 * time.Millisecond)
+		if nodeID != "test-node-id" {
+			return nil, errors.New("node id not found")
+		}
+
+		return downloads, nil
+	}
+
+	manager, err := createTestManager(tester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.SetEncryptionPIN(securityPIN)
+	manager.Start()
+	defer manager.destroy()
+
+	manager.RequestBackup()
+	waitForBackupEnd(tester.MsgChannel)
+	paths, err := manager.Restore("test-node-id", securityPIN)
+	if err != nil {
+		t.Fatal("Restore failed", err)
+	}
+	defer func() {
+		for _, f := range paths {
+			os.Remove(f)
+		}
+	}()
+
+	content, err := ioutil.ReadFile(paths[0])
+	if err != nil {
+		t.Error("Restore failed", err)
+	}
+	if bytes.Compare(content, originalContent) != 0 {
+		t.Error("Restore failed to decreypt file", err, content)
+	}
+}
+
+func waitForBackupEnd(msgChan chan data.NotificationEvent) {
+	for {
+		event := <-msgChan
+		fmt.Println("waitForBackupEnd ", event)
+		if event.Type != data.NotificationEvent_BACKUP_REQUEST {
+			break
+		}
 	}
 }

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -211,7 +211,7 @@ func RestoreBackup(nodeID string) (err error) {
 	if err = getBreezApp().Stop(); err != nil {
 		return err
 	}
-	if _, err = getBreezApp().BackupManager.Restore(nodeID); err != nil {
+	if _, err = getBreezApp().BackupManager.Restore(nodeID, ""); err != nil {
 		return err
 	}
 	breezApp, err = breez.NewApp(getBreezApp().GetWorkingDir(), appServices)


### PR DESCRIPTION
This PR adds the ability to set an encryption key to the `backup.Manager` to be used when encrypting the files before uploading them using the chosen provider.
The encryption key is optional and if not set the files won't be encrypted.
When the encryption key is used in a specific backup, the "Snapshot" is marked as encrypted (using custom property in Gdrive provider for example). This is so we know in the restore flow for each snapshot if it requires a key to decrypt the files.
We can also use this mark to differentiate encrypted snapshots from non-encrypted ones in the UI (show lock icon or similar...).
The PR is backward compatible and also add some tests for this new flow.