### PR TITLE
Subswap multi utxo fix

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -1,7 +1,6 @@
 package bindings
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -294,36 +293,6 @@ AddFundsInit is part of the binding inteface which is delegated to breez.AddFund
 */
 func AddFundsInit(breezID string) ([]byte, error) {
 	return marshalResponse(getBreezApp().SwapService.AddFundsInit(breezID))
-}
-
-/*
-GetRefundableSwapAddresses returns all addresses that are refundable, e.g expired and not paid
-*/
-func GetRefundableSwapAddresses() ([]byte, error) {
-	refundableAddresses, err := getBreezApp().SwapService.GetRefundableAddresses()
-	if err != nil {
-		return nil, err
-	}
-
-	var rpcAddresses []*data.SwapAddressInfo
-	for _, a := range refundableAddresses {
-		rpcAddresses = append(rpcAddresses, &data.SwapAddressInfo{
-			Address:                 a.Address,
-			PaymentHash:             hex.EncodeToString(a.PaymentHash),
-			ConfirmedAmount:         a.ConfirmedAmount,
-			ConfirmedTransactionIds: a.ConfirmedTransactionIds,
-			PaidAmount:              a.PaidAmount,
-			LockHeight:              a.LockHeight,
-			ErrorMessage:            a.ErrorMessage,
-			LastRefundTxID:          a.LastRefundTxID,
-		})
-	}
-
-	addressList := &data.SwapAddressList{
-		Addresses: rpcAddresses,
-	}
-	fmt.Printf("GetRefundableSwapAddresses returned %v addresses", len(rpcAddresses))
-	return marshalResponse(addressList, nil)
 }
 
 //Refund transfers the funds in address to the user destination address

--- a/swapfunds/addfunds.go
+++ b/swapfunds/addfunds.go
@@ -210,28 +210,6 @@ func (s *Service) GetFundStatus(notificationToken string) (*data.FundStatusReply
 	return &statusReply, nil
 }
 
-//GetRefundableAddresses returns all addresses that are refundable, e.g: expired and not paid
-func (s *Service) GetRefundableAddresses() ([]*db.SwapAddressInfo, error) {
-	lnclient := s.daemonAPI.APIClient()
-	info, err := lnclient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
-	if err != nil {
-		return nil, err
-	}
-
-	refundable, err := s.breezDB.FetchSwapAddresses(func(a *db.SwapAddressInfo) bool {
-		refundable := a.LockHeight < info.BlockHeight && a.ConfirmedAmount > 0 && a.LastRefundTxID == ""
-		if refundable {
-			s.log.Infof("found refundable address: %v lockHeight=%v, amount=%v, currentHeight=%v", a.Address, a.LockHeight, a.ConfirmedAmount, info.BlockHeight)
-		}
-		return refundable
-	})
-
-	if err != nil {
-		return nil, err
-	}
-	return refundable, nil
-}
-
 //Refund broadcast a refund transaction for a sub swap address.
 func (s *Service) Refund(address, refundAddress string) (string, error) {
 	s.log.Infof("Starting refund flow...")


### PR DESCRIPTION
This PR fixes the submarine swap flow where user sends additional money to a sub swap address after the swap was completed.
Currently such kind of addresses are ignored, leaving the user with uncertainty.
The code change is to identify such cases and mark those addresses for a refund.
The fix includes:
1. Remove the filter of addresses we already paid and instead fetch all addresses.
2. Consider all utxos when calculating the LockHeight and not only the first one.
3. In addition the `GetRefundableAddresses` function that is not in use anymore was removed.