### PR TITLE
Add mission control commands to RPC interface.

### DIFF
--- a/lnnode/daemon.go
+++ b/lnnode/daemon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/breezbackuprpc"
 	"github.com/lightningnetwork/lnd/lnrpc/submarineswaprpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/signal"
 )
 
@@ -88,6 +89,12 @@ func (d *Daemon) BreezBackupClient() breezbackuprpc.BreezBackuperClient {
 	d.Lock()
 	defer d.Unlock()
 	return d.breezBackupClient
+}
+
+func (d *Daemon) RouterClient() routerrpc.RouterClient {
+	d.Lock()
+	defer d.Unlock()
+	return d.routerClient
 }
 
 // RestartDaemon is used to restart a daemon that from some reason failed to start

--- a/lnnode/init.go
+++ b/lnnode/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/breezbackuprpc"
 	"github.com/lightningnetwork/lnd/lnrpc/submarineswaprpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/subscribe"
 )
 
@@ -25,6 +26,7 @@ type API interface {
 	APIClient() lnrpc.LightningClient
 	SubSwapClient() submarineswaprpc.SubmarineSwapperClient
 	BreezBackupClient() breezbackuprpc.BreezBackuperClient
+	RouterClient() routerrpc.RouterClient
 }
 
 // Daemon contains data regarding the lightning daemon.
@@ -43,6 +45,7 @@ type Daemon struct {
 	lightningClient           lnrpc.LightningClient
 	subswapClient             submarineswaprpc.SubmarineSwapperClient
 	breezBackupClient         breezbackuprpc.BreezBackuperClient
+	routerClient			  routerrpc.RouterClient
 	ntfnServer                *subscribe.Server
 	quitChan                  chan struct{}
 }

--- a/lnnode/notifier.go
+++ b/lnnode/notifier.go
@@ -54,7 +54,7 @@ func (d *Daemon) SubscribeEvents() (*subscribe.Client, error) {
 
 func (d *Daemon) startSubscriptions() error {
 	var err error
-	lnclient, peersClient, backupEventClient, subswapClient, breezBackupClient, err := newLightningClient(d.cfg)
+	lnclient, peersClient, backupEventClient, subswapClient, breezBackupClient, routerClient, err := newLightningClient(d.cfg)
 	if err != nil {
 		return err
 	}
@@ -63,6 +63,7 @@ func (d *Daemon) startSubscriptions() error {
 	d.lightningClient = lnclient
 	d.subswapClient = subswapClient
 	d.breezBackupClient = breezBackupClient
+	d.routerClient = routerClient
 	d.Unlock()
 
 	info, chainErr := d.lightningClient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})


### PR DESCRIPTION
This PR adds two commands that accessible for the user from the dev interface:
querymc - which shows the mission control snapshot.
resetmc - which reset the historical mission control data.