### PR TITLE
Considering the commit fee possible change

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -197,6 +197,14 @@ func (a *Service) getRecievePayLimit() (maxReceive, maxPay, maxReserve int64, er
 	for _, b := range channels.Channels {
 		thisChannelCanReceive := b.RemoteBalance - b.RemoteChanReserve
 		thisChannelCanPay := b.LocalBalance - b.LocalChanReserve
+		if !b.Initiator {
+			// In case this is a remote initated channel we will take a buffer of half commit fee size
+			// to ensure the remote balance won't get too close to the channel reserve.
+			thisChannelCanReceive -= b.CommitFee / 2
+		} else {
+			// Otherwise we need to restrict how much we can pay at the same manner
+			thisChannelCanPay -= b.CommitFee / 2
+		}
 		processChannel(thisChannelCanReceive, thisChannelCanPay, b.LocalChanReserve)
 	}
 


### PR DESCRIPTION
This PR adds a safety mechanism for https://github.com/lightningnetwork/lnd/issues/3429 until we understand how/if this should be solved in LND.
We take into consideration additional threshold of half of commit fee to cover cases where the commit fee changes and not allowing spend/receive using the channel.
Whether to use this threshold when calculating maxReceive or maxPay per channel is determined by who is the initiator which currently is the commit fee payer.