### PR TITLE
implement api to reset chain service information.

### DIFF
--- a/chainservice/bootstrap.go
+++ b/chainservice/bootstrap.go
@@ -26,6 +26,27 @@ var (
 	bootstrapMu sync.Mutex
 )
 
+func ResetChainService(workingDir string) error {
+	bootstrapMu.Lock()
+	defer bootstrapMu.Unlock()
+	config, err := config.GetConfig(workingDir)
+	if err != nil {
+		return err
+	}
+	neutrinoDataDir := neutrinoDataDir(workingDir, config.Network)	
+	if err = os.Remove(path.Join(neutrinoDataDir, "neutrino.db")); err != nil {
+		return err
+	}
+	if err = os.Remove(path.Join(neutrinoDataDir, "reg_filter_headers.bin")); err != nil {
+		return err
+	}
+	if err = os.Remove(path.Join(neutrinoDataDir, "block_headers.bin")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func NeedsBootstrap(workingDir string) (bool, error) {
 	bootstrapMu.Lock()
 	defer bootstrapMu.Unlock()


### PR DESCRIPTION
This PR adds API in breez library to reset the chain service information.
More specifically delete neutrino headers, filters and db files.
The effect of this is that on next restart they will be rebuilt again allowing recovery in case of corruption.