### PR TITLE
Optimize remove funds

### DIFF
--- a/db/funds.go
+++ b/db/funds.go
@@ -34,7 +34,7 @@ type SwapAddressInfo struct {
 	EnteredMempool  bool
 
 	//refund
-	LastRefundTxID string	
+	LastRefundTxID string
 }
 
 // Confirmed returns true if the transaction has confirmed in the past.
@@ -181,6 +181,18 @@ func (db *DB) UpdateRedeemTxForPayment(hash string, txID string) error {
 		redeemableHashesB := tx.Bucket([]byte(redeemableHashesBucket))
 		return redeemableHashesB.Delete([]byte(hash))
 	})
+}
+
+// IsInvoiceHashPaid returns true if the payReqHash was paid by this client.
+func (db *DB) IsInvoiceHashPaid(payReqHash string) (bool, error) {
+	var paid bool
+	err := db.View(func(tx *bolt.Tx) error {
+		hashB := tx.Bucket([]byte(paymentsHashBucket))
+		paymentIndex := hashB.Get([]byte(payReqHash))
+		paid = paymentIndex != nil
+		return nil
+	})
+	return paid, err
 }
 
 func serializeSwapAddressInfo(s *SwapAddressInfo) ([]byte, error) {

--- a/swapfunds/removefunds.go
+++ b/swapfunds/removefunds.go
@@ -66,8 +66,19 @@ func (s *Service) redeemAllRemovedFunds() error {
 		s.log.Errorf("failed to fetchRedeemablePaymentHashes, %v", err)
 		return err
 	}
+
 	for _, hash := range hashes {
 		s.log.Infof("Redeeming transaction for has %v", hash)
+		paid, err := s.breezDB.IsInvoiceHashPaid(hash)
+		if err != nil {
+			s.log.Infof("Skipping payment hash %v as couldn't fetch payment from db %v", hash, err)
+			continue
+		}
+		if !paid {
+			s.log.Infof("Skipping payment hash %v as it was not paid by this client")
+			continue
+		}
+
 		txID, err := s.redeemRemovedFundsForHash(hash)
 		if err != nil {
 			s.log.Errorf("failed to redeem funds for hash %v, %v", hash, err)


### PR DESCRIPTION
This PR ensures we don't try to redeem funds from the swapper unless we know we paid the invoice.
This ensures we won't retry redeem funds that we don't deserve and risk in falling into rate limit error.