### PR TITLE
addfunds: don't mark paid address as confirmed.

### DIFF
--- a/swapfunds/addfunds.go
+++ b/swapfunds/addfunds.go
@@ -195,13 +195,17 @@ func (s *Service) GetFundStatus(notificationToken string) (*data.FundStatusReply
 		// In case the transactino is confirmed and has positive output, we will check
 		// if it is ready for completing the process by the client or it has error.
 		if a.ConfirmedAmount > 0 {
-			if a.LockHeight > info.BlockHeight && data.SwapError(a.SwapErrorReason) == data.SwapError_NO_ERROR {
+			paid := a.PaidAmount > 0
+
+			if !paid && a.LockHeight > info.BlockHeight && data.SwapError(a.SwapErrorReason) == data.SwapError_NO_ERROR {
 				statusReply.ConfirmedAddresses = append(statusReply.ConfirmedAddresses, createRPCSwapAddressInfo(a))
 				continue
 			}
 
-			s.log.Infof("Adding refundable address: %v", a.Address)
-			statusReply.RefundableAddresses = append(statusReply.RefundableAddresses, createRPCSwapAddressInfo(a))
+			if !paid || a.LockHeight <= info.BlockHeight {
+				s.log.Infof("Adding refundable address: %v", a.Address)
+				statusReply.RefundableAddresses = append(statusReply.RefundableAddresses, createRPCSwapAddressInfo(a))
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this PR we marked addresses with positive confirmed amount as "confirmed".
The "confirmed" addresses should be such that we need to redeem payments for them.
This created a bug where when we got the lightning payment as part of the swap the address stayed as "confirmed" since its confirmed amount hasn't change (it will only change after the server has redeemed and confirmed).
The client mistakenly tried to redeem repetitively, showing UI for "transferring funds..."
This PR ensures that addresses that we already paid are not candidate for a swap and won't marked as confirmed.
If use has sent funds to this address after we paid it will be shown as refundable.