### PR TITLE
Prepare mnemonics backup

### DIFF
--- a/app.go
+++ b/app.go
@@ -99,7 +99,7 @@ func (a *App) RestartDaemon() error {
 
 // Restore is the breez API for restoring a specific nodeID using the configured
 // backup backend provider.
-func (a *App) Restore(nodeID string, key string) error {
+func (a *App) Restore(nodeID string, key []byte) error {
 	a.log.Infof("Restore nodeID = %v", nodeID)
 	if err := a.releaseBreezDB(); err != nil {
 		return err

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -4,10 +4,9 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"	
 	"io"
 	"io/ioutil"
-	"os"
+	"os"	
 )
 
 func encryptFile(source, dest string, key []byte) error {
@@ -40,7 +39,7 @@ func encryptFile(source, dest string, key []byte) error {
 	return nil
 }
 
-func decryptFile(source, dest string, key []byte) error {
+func decryptFile(source, dest string, key []byte) error {	
 	fileContent, err := ioutil.ReadFile(source)
 	if err != nil {
 		return err
@@ -69,12 +68,4 @@ func decryptFile(source, dest string, key []byte) error {
 	}
 
 	return nil
-}
-
-func generateEncryptionKey(pin string) []byte {
-	if pin == "" {
-		return nil
-	}
-	sum := sha256.Sum256([]byte(pin))
-	return sum[:]
 }

--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -6,7 +6,7 @@ import (
 	"crypto/rand"
 	"io"
 	"io/ioutil"
-	"os"	
+	"os"
 )
 
 func encryptFile(source, dest string, key []byte) error {
@@ -39,7 +39,7 @@ func encryptFile(source, dest string, key []byte) error {
 	return nil
 }
 
-func decryptFile(source, dest string, key []byte) error {	
+func decryptFile(source, dest string, key []byte) error {
 	fileContent, err := ioutil.ReadFile(source)
 	if err != nil {
 		return err

--- a/backup/drive.go
+++ b/backup/drive.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	backupIDProperty           = "backupID"
-	activeBackupFolderProperty = "activeBackupFolder"
-	backupEncryptedProperty    = "backupEncrypted" //legacy
-	backupEncryptionTypeProperty    = "backupEncryptionType"
+	backupIDProperty             = "backupID"
+	activeBackupFolderProperty   = "activeBackupFolder"
+	backupEncryptedProperty      = "backupEncrypted" //legacy
+	backupEncryptionTypeProperty = "backupEncryptionType"
 )
 
 // driveServiceError is the type of error this provider returns in case
@@ -221,8 +221,8 @@ func (p *GoogleDriveProvider) UploadBackupFiles(files []string, nodeID string, e
 
 	// Update active backup folder for this specific node folder
 	folderUpdate := &drive.File{AppProperties: map[string]string{
-		activeBackupFolderProperty: newBackupFolder.Id,
-		backupEncryptionTypeProperty: encryptionType,		
+		activeBackupFolderProperty:   newBackupFolder.Id,
+		backupEncryptionTypeProperty: encryptionType,
 	}}
 	_, err = p.driveService.Files.Update(nodeFolder.Id, folderUpdate).Do()
 	if err != nil {

--- a/backup/init.go
+++ b/backup/init.go
@@ -37,6 +37,7 @@ type Manager struct {
 	quitChan          chan struct{}
 	log               btclog.Logger
 	encryptionKey     []byte
+	encryptionType    string
 	mu                sync.Mutex
 	wg                sync.WaitGroup
 }

--- a/backup/interface.go
+++ b/backup/interface.go
@@ -2,10 +2,11 @@ package backup
 
 // SnapshotInfo is an existing backup information for a specific node id.
 type SnapshotInfo struct {
-	NodeID       string
-	BackupID     string
-	Encrypted    bool
-	ModifiedTime string
+	NodeID         string
+	BackupID       string
+	Encrypted      bool
+	EncryptionType string
+	ModifiedTime   string
 }
 
 // Service is the interface to expose from this package as Backup Service API.
@@ -19,7 +20,7 @@ type Service interface {
 // Provider represents the functionality needed to be implemented for any backend backup
 // storage provider. This provider will be used and inststiated by the service.
 type Provider interface {
-	UploadBackupFiles(files []string, nodeID string, encrypted bool) error
+	UploadBackupFiles(files []string, nodeID string, encryptionType string) error
 	AvailableSnapshots() ([]SnapshotInfo, error)
 	DownloadBackupFiles(nodeID, backupID string) ([]string, error)
 }

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -168,7 +168,8 @@ func (b *Manager) Start() error {
 				}
 
 				b.mu.Lock()				
-				encryptionKey := b.encryptionKey				
+				encryptionKey := b.encryptionKey
+				encryptionType := b.encryptionType				
 				b.mu.Unlock()
 
 				useEncryption, err := b.db.useEncryption()
@@ -214,7 +215,7 @@ func (b *Manager) Start() error {
 					}
 				}
 
-				if err := b.provider.UploadBackupFiles(paths, nodeID, b.encryptionType); err != nil {
+				if err := b.provider.UploadBackupFiles(paths, nodeID, encryptionType); err != nil {
 					b.log.Errorf("error in backup %v", err)
 					b.notifyBackupFailed(err)
 					continue

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -75,7 +75,7 @@ func (b *Manager) Restore(nodeID string, key []byte) ([]string, error) {
 	}
 
 	// If we got an encryption key, let's decrypt the files
-	if key != nil {		
+	if key != nil {
 		for i, p := range files {
 			destPath := p + ".decrypted"
 			err = decryptFile(p, destPath, key)
@@ -167,9 +167,9 @@ func (b *Manager) Start() error {
 					continue
 				}
 
-				b.mu.Lock()				
+				b.mu.Lock()
 				encryptionKey := b.encryptionKey
-				encryptionType := b.encryptionType				
+				encryptionType := b.encryptionType
 				b.mu.Unlock()
 
 				useEncryption, err := b.db.useEncryption()
@@ -234,10 +234,10 @@ func (b *Manager) Start() error {
 }
 
 // SetEncryptionKey sets the pin which should be used to encrypt the backup files
-func (b *Manager) SetEncryptionKey(encKey []byte, encryptionType string) error {	
+func (b *Manager) SetEncryptionKey(encKey []byte, encryptionType string) error {
 	if err := b.db.setUseEncryption(len(encKey) > 0); err != nil {
 		return err
-	}	
+	}
 
 	b.mu.Lock()
 	b.encryptionKey = encKey

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -233,7 +233,7 @@ func (b *Manager) Start() error {
 	return nil
 }
 
-// SetEncryptionKey sets the pin which should be used to encrypt the backup files
+// SetEncryptionKey sets the key which should be used to encrypt the backup files
 func (b *Manager) SetEncryptionKey(encKey []byte, encryptionType string) error {
 	if err := b.db.setUseEncryption(len(encKey) > 0); err != nil {
 		return err

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -139,10 +139,11 @@ func Init(tempDir string, workingDir string, services AppServices) (err error) {
 	return err
 }
 
-// SetPinCode sets the security pin code to the backup manager so it
+// SetBackupEncryptionKey sets the security key to the backup manager so it
 // can be used in encrypting backup files.
-func SetPinCode(pinCode string) error {
-	return getBreezApp().BackupManager.SetEncryptionPIN(pinCode)
+func SetBackupEncryptionKey(key []byte, encryptionType string) error {
+	encKey := append([]byte(nil), key...)
+	return getBreezApp().BackupManager.SetEncryptionKey(encKey, encryptionType)
 }
 
 // NeedsBootstrap checks if bootstrap header is needed.
@@ -253,11 +254,12 @@ func RequestBackup() {
 /*
 RestoreBackup is part of the binding inteface which is delegated to breez.RestoreBackup
 */
-func RestoreBackup(nodeID string, pinCode string) (err error) {
+func RestoreBackup(nodeID string, encryptionKey []byte) (err error) {
 	if err = getBreezApp().Stop(); err != nil {
 		return err
 	}
-	if _, err = getBreezApp().BackupManager.Restore(nodeID, pinCode); err != nil {
+	encKey := append([]byte(nil), encryptionKey...)
+	if _, err = getBreezApp().BackupManager.Restore(nodeID, encKey); err != nil {
 		return err
 	}
 	breezApp, err = breez.NewApp(getBreezApp().GetWorkingDir(), appServices)


### PR DESCRIPTION
This PR is a preparation of the code to be able to get more than one key type for the encryption key.
In general it simplify the API by only require that the key will be 256 bit length and removes the hashing that was done previously.
This enables the upper layer (UI) to send raw keys generated from different sources (like mnemonics) and keep the key type as metadata for the backup snapshot.
The key type is then used in restore by the upper layer to choose the interface for the user.
in drive the key type metadata is saved under a new metadata key: "`backupEncryptionTypeProperty`" and maintains backward compatibility with the old deprecated key: "`backupEncryptedProperty`"