### PR TITLE
Native backup provider

### DIFF
--- a/bindings/native_backup_provider.go
+++ b/bindings/native_backup_provider.go
@@ -1,0 +1,53 @@
+package bindings
+
+import (
+	"strings"
+	"encoding/json"
+
+	"github.com/breez/breez/backup"
+	"github.com/btcsuite/btclog"
+)
+
+type NativeBackupProvider interface {
+	UploadBackupFiles(files string, nodeID string, encryptionType string) error
+	AvailableSnapshots() (string, error)
+	DownloadBackupFiles(nodeID, backupID string) (string, error)
+}
+
+// NativeBackupProviderBridge is a bridge for using a native implemented provider in the backup manager.
+type NativeBackupProviderBridge struct {
+	nativeProvider NativeBackupProvider
+}
+
+func (b *NativeBackupProviderBridge) UploadBackupFiles(files []string, nodeID string, encryptionType string) error {
+	return b.nativeProvider.UploadBackupFiles(strings.Join(files, ","), nodeID, encryptionType)
+}
+
+func (b *NativeBackupProviderBridge) AvailableSnapshots() ([]backup.SnapshotInfo, error) {
+	snapshotsString, err := b.nativeProvider.AvailableSnapshots()
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshots []backup.SnapshotInfo
+	if err := json.Unmarshal([]byte(snapshotsString), &snapshots); err != nil {
+		return nil, err
+	}
+
+	return snapshots, nil
+}
+
+func (b *NativeBackupProviderBridge) DownloadBackupFiles(nodeID, backupID string) ([]string, error) {
+	files, err := b.nativeProvider.DownloadBackupFiles(nodeID, backupID)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(files, ","), nil
+}
+
+// RegisterNativeBackupProvider registered a native backup provider
+func RegisterNativeBackupProvider(name string, provider NativeBackupProvider) {
+	backup.RegisterProvider(name, func(authService backup.AuthService, log btclog.Logger) (backup.Provider, error) {
+		return &NativeBackupProviderBridge{nativeProvider: provider}, nil
+	})
+}

--- a/bindings/native_backup_provider.go
+++ b/bindings/native_backup_provider.go
@@ -8,6 +8,10 @@ import (
 	"github.com/btcsuite/btclog"
 )
 
+// NativeBackupProvider is interface that serves as backup provider and is intended to be 
+// implemented by the native platform and injected to breez library.
+// It is usefull when it is more nature to implement the provider in the native environment
+// rather than in go API.
 type NativeBackupProvider interface {
 	UploadBackupFiles(files string, nodeID string, encryptionType string) error
 	AvailableSnapshots() (string, error)
@@ -19,10 +23,12 @@ type NativeBackupProviderBridge struct {
 	nativeProvider NativeBackupProvider
 }
 
+// UploadBackupFiles is called when files needs to be uploaded as part of the backup
 func (b *NativeBackupProviderBridge) UploadBackupFiles(files []string, nodeID string, encryptionType string) error {
 	return b.nativeProvider.UploadBackupFiles(strings.Join(files, ","), nodeID, encryptionType)
 }
 
+// AvailableSnapshots is called when querying for all available nodes backups.
 func (b *NativeBackupProviderBridge) AvailableSnapshots() ([]backup.SnapshotInfo, error) {
 	snapshotsString, err := b.nativeProvider.AvailableSnapshots()
 	if err != nil {
@@ -37,6 +43,7 @@ func (b *NativeBackupProviderBridge) AvailableSnapshots() ([]backup.SnapshotInfo
 	return snapshots, nil
 }
 
+// DownloadBackupFiles is called when restring from a backup snapshot.
 func (b *NativeBackupProviderBridge) DownloadBackupFiles(nodeID, backupID string) ([]string, error) {
 	files, err := b.nativeProvider.DownloadBackupFiles(nodeID, backupID)
 	if err != nil {


### PR DESCRIPTION
This PR adds the ability to inject a backup provider from upper layers.
For some backup providers implementation, like iCloud, it is more natural to use the native API rather than be implemented in go.
The PR does the following:
1. Define a "`NativeBackupProvider`" interface to be implemented by the native layer.
2. Implement a "`NativeBackupProviderBridge`" that bridges the above interface with the real backup provider interface exists in the `backup` package.
3. Add endpoint to register a native backup provider.