### PR TITLE
Add accountName to the return value of UploadBackupFiles.

### DIFF
--- a/backup/interface.go
+++ b/backup/interface.go
@@ -20,7 +20,7 @@ type Service interface {
 // Provider represents the functionality needed to be implemented for any backend backup
 // storage provider. This provider will be used and inststiated by the service.
 type Provider interface {
-	UploadBackupFiles(files []string, nodeID string, encryptionType string) error
+	UploadBackupFiles(files []string, nodeID string, encryptionType string) (string, error)
 	AvailableSnapshots() ([]SnapshotInfo, error)
 	DownloadBackupFiles(nodeID, backupID string) ([]string, error)
 }

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -233,14 +233,15 @@ func (b *Manager) Start() error {
 					}
 				}
 
-				if err := provider.UploadBackupFiles(paths, nodeID, encryptionType); err != nil {
+				accountName, err := provider.UploadBackupFiles(paths, nodeID, encryptionType)
+				if err != nil {
 					b.log.Errorf("error in backup %v", err)
 					b.notifyBackupFailed(err)
 					continue
 				}
 				b.db.markBackupRequestCompleted(pendingID)
 				b.log.Infof("backup finished succesfully")
-				b.onServiceEvent(data.NotificationEvent{Type: data.NotificationEvent_BACKUP_SUCCESS})
+				b.onServiceEvent(data.NotificationEvent{Type: data.NotificationEvent_BACKUP_SUCCESS, Data: []string{accountName}})
 			case <-b.quitChan:
 				return
 			}

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -26,7 +26,7 @@ type MockTester struct {
 	downloadCounter         int
 	preparer                DataPreparer
 	lastNotification        data.NotificationEvent
-	UploadBackupFilesImpl   func(files []string, nodeID string, encryptionType string) error
+	UploadBackupFilesImpl   func(files []string, nodeID string, encryptionType string) (string, error)
 	AvailableSnapshotsImpl  func() ([]SnapshotInfo, error)
 	DownloadBackupFilesImpl func(nodeID, backupID string) ([]string, error)
 	MsgChannel              chan data.NotificationEvent
@@ -44,7 +44,7 @@ func newDefaultMockTester() *MockTester {
 		p.downloadCounter++
 		return []string{}, nil
 	}
-	p.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) error {
+	p.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) (string, error) {
 		time.Sleep(time.Millisecond * 10)
 		p.uploadCounter++
 		return nil
@@ -53,7 +53,7 @@ func newDefaultMockTester() *MockTester {
 	return &p
 }
 
-func (m *MockTester) UploadBackupFiles(files []string, nodeID string, encryptionType string) error {
+func (m *MockTester) UploadBackupFiles(files []string, nodeID string, encryptionType string) (string, error) {
 	return m.UploadBackupFilesImpl(files, nodeID, "")
 }
 func (m *MockTester) AvailableSnapshots() ([]SnapshotInfo, error) {
@@ -188,8 +188,8 @@ func TestErrorInPrepareBackup(t *testing.T) {
 
 func TestErrorInUpload(t *testing.T) {
 	tester := newDefaultMockTester()
-	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) error {
-		return errors.New("failed to upload files")
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) (string, error) {
+		return "", errors.New("failed to upload files")
 	}
 	manager, err := createTestManager(tester)
 	if err != nil {
@@ -210,8 +210,8 @@ func TestErrorInUpload(t *testing.T) {
 
 func TestAuthError(t *testing.T) {
 	tester := newDefaultMockTester()
-	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) error {
-		return &mockAuthError{}
+	tester.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) (string, error) {
+		return "", &mockAuthError{}
 	}
 	manager, err := createTestManager(tester)
 	if err != nil {

--- a/backup/manager_test.go
+++ b/backup/manager_test.go
@@ -47,7 +47,7 @@ func newDefaultMockTester() *MockTester {
 	p.UploadBackupFilesImpl = func(files []string, nodeID string, encryptionType string) (string, error) {
 		time.Sleep(time.Millisecond * 10)
 		p.uploadCounter++
-		return nil
+		return "", nil
 	}
 	p.MsgChannel = make(chan data.NotificationEvent, 100)
 	return &p

--- a/bindings/native_backup_provider.go
+++ b/bindings/native_backup_provider.go
@@ -13,7 +13,7 @@ import (
 // It is usefull when it is more nature to implement the provider in the native environment
 // rather than in go API.
 type NativeBackupProvider interface {
-	UploadBackupFiles(files string, nodeID string, encryptionType string) error
+	UploadBackupFiles(files string, nodeID string, encryptionType string) (string, error)
 	AvailableSnapshots() (string, error)
 	DownloadBackupFiles(nodeID, backupID string) (string, error)
 }
@@ -40,12 +40,12 @@ type NativeBackupProviderBridge struct {
 }
 
 // UploadBackupFiles is called when files needs to be uploaded as part of the backup
-func (b *NativeBackupProviderBridge) UploadBackupFiles(files []string, nodeID string, encryptionType string) error {
-	err := b.nativeProvider.UploadBackupFiles(strings.Join(files, ","), nodeID, encryptionType)
+func (b *NativeBackupProviderBridge) UploadBackupFiles(files []string, nodeID string, encryptionType string) (string, error) {
+	acc, err := b.nativeProvider.UploadBackupFiles(strings.Join(files, ","), nodeID, encryptionType)
 	if err != nil {
-		return &nativeProviderError{err: err}
+		return "", &nativeProviderError{err: err}
 	}
-	return nil
+	return acc, nil
 }
 
 // AvailableSnapshots is called when querying for all available nodes backups.


### PR DESCRIPTION
This PR changes the interface of the "UploadBackupFiles" of the backup provider to return also the account name on behalf of which the backup was executed.
This is to enable the higher level layer to present this account as part of the last successful backup.