### PR TITLE
Job fixes

### DIFF
--- a/chainservice/bootstrap.go
+++ b/chainservice/bootstrap.go
@@ -3,7 +3,6 @@ package chainservice
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"os"
 	"path"
 	"sync"
@@ -95,7 +94,8 @@ func Bootstrap(workingDir string) error {
 	logger = logBackend.Logger("CHAIN")
 	logger.Infof("Bootstrap started")
 	if service != nil {
-		return errors.New("Chain service already created, can't bootstrap")
+		logger.Info("Chain service already created, already bootstrapped")
+		return nil
 	}
 
 	bootstrapped, err := Bootstrapped(workingDir)

--- a/chainservice/init.go
+++ b/chainservice/init.go
@@ -134,17 +134,16 @@ func createService(workingDir string, breezDB *db.DB) (*neutrino.ChainService, r
 }
 
 func stopService() error {
-
-	if walletDB != nil {
-		if err := walletDB.Close(); err != nil {
-			return err
-		}
-	}
 	if service != nil {
 		if err := service.Stop(); err != nil {
 			return err
 		}
 		service = nil
+	}
+	if walletDB != nil {
+		if err := walletDB.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR contains two fixes related to the job functionality:
1. Change the chainservice stop method to first stop neutrino and afterwards close the db. This prevents a crash in the job.
2. Don't return error in Bootstrap in case the chainservice already created. We can safely assume bootstrap already done.