### PR TITLE
Dynamic fee estimate

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -437,7 +437,7 @@ func SendWalletCoins(sendCoinsRequest []byte) (string, error) {
 /*
 GetDefaultOnChainFeeRate is part of the binding inteface which is delegated to breez.GetDefaultOnChainFeeRate
 */
-func GetDefaultOnChainFeeRate() int64 {
+func GetDefaultOnChainFeeRate() (int64, error) {
 	return getBreezApp().AccountService.GetDefaultSatPerByteFee()
 }
 

--- a/lnnode/client.go
+++ b/lnnode/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/breezbackuprpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/submarineswaprpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -37,7 +38,9 @@ func newLightningClient(cfg *config.Config) (
 	lnrpc.LightningClient, backuprpc.BackupClient,
 	submarineswaprpc.SubmarineSwapperClient,
 	breezbackuprpc.BreezBackuperClient,
-	routerrpc.RouterClient, error) {
+	routerrpc.RouterClient,
+	walletrpc.WalletKitClient,
+	error) {
 
 	appWorkingDir := cfg.WorkingDir
 	network := cfg.Network
@@ -45,7 +48,7 @@ func newLightningClient(cfg *config.Config) (
 	tlsCertPath := filepath.Join(appWorkingDir, defaultTLSCertFilename)
 	creds, err := credentials.NewClientTLSFromFile(tlsCertPath, "")
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Create a dial options array.
@@ -57,11 +60,11 @@ func newLightningClient(cfg *config.Config) (
 	macPath := filepath.Join(macaroonDir, defaultMacaroonFilename)
 	macBytes, err := ioutil.ReadFile(macPath)
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 	mac := &macaroon.Macaroon{}
 	if err = mac.UnmarshalBinary(macBytes); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Now we append the macaroon credentials to the dial options.
@@ -70,7 +73,7 @@ func newLightningClient(cfg *config.Config) (
 
 	conn, err := lnd.MemDial()
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	// We need to use a custom dialer so we can also connect to unix sockets
@@ -83,7 +86,7 @@ func newLightningClient(cfg *config.Config) (
 	)
 	grpcCon, err := grpc.Dial("localhost", opts...)
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	return lnrpc.NewLightningClient(grpcCon),
@@ -91,5 +94,6 @@ func newLightningClient(cfg *config.Config) (
 		submarineswaprpc.NewSubmarineSwapperClient(grpcCon),
 		breezbackuprpc.NewBreezBackuperClient(grpcCon),
 		routerrpc.NewRouterClient(grpcCon),
+		walletrpc.NewWalletKitClient(grpcCon),
 		nil
 }

--- a/lnnode/daemon.go
+++ b/lnnode/daemon.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/breezbackuprpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/submarineswaprpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/signal"
 )
 
@@ -90,6 +91,12 @@ func (d *Daemon) RouterClient() routerrpc.RouterClient {
 	d.Lock()
 	defer d.Unlock()
 	return d.routerClient
+}
+
+func (d *Daemon) WalletKitClient() walletrpc.WalletKitClient {
+	d.Lock()
+	defer d.Unlock()
+	return d.walletKitClient
 }
 
 // RestartDaemon is used to restart a daemon that from some reason failed to start

--- a/lnnode/init.go
+++ b/lnnode/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/breezbackuprpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/submarineswaprpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/subscribe"
 )
 
@@ -26,6 +27,7 @@ type API interface {
 	SubSwapClient() submarineswaprpc.SubmarineSwapperClient
 	BreezBackupClient() breezbackuprpc.BreezBackuperClient
 	RouterClient() routerrpc.RouterClient
+	WalletKitClient() walletrpc.WalletKitClient
 }
 
 // Daemon contains data regarding the lightning daemon.
@@ -43,6 +45,7 @@ type Daemon struct {
 	subswapClient     submarineswaprpc.SubmarineSwapperClient
 	breezBackupClient breezbackuprpc.BreezBackuperClient
 	routerClient      routerrpc.RouterClient
+	walletKitClient   walletrpc.WalletKitClient
 	ntfnServer        *subscribe.Server
 	quitChan          chan struct{}
 	startBeforeSync   bool

--- a/lnnode/notifier.go
+++ b/lnnode/notifier.go
@@ -53,7 +53,7 @@ func (d *Daemon) SubscribeEvents() (*subscribe.Client, error) {
 
 func (d *Daemon) startSubscriptions() error {
 	var err error
-	lnclient, backupEventClient, subswapClient, breezBackupClient, routerClient, err := newLightningClient(d.cfg)
+	lnclient, backupEventClient, subswapClient, breezBackupClient, routerClient, walletKitClient, err := newLightningClient(d.cfg)
 	if err != nil {
 		return err
 	}
@@ -63,6 +63,7 @@ func (d *Daemon) startSubscriptions() error {
 	d.subswapClient = subswapClient
 	d.breezBackupClient = breezBackupClient
 	d.routerClient = routerClient
+	d.walletKitClient = walletKitClient
 	d.Unlock()
 
 	info, chainErr := d.lightningClient.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})


### PR DESCRIPTION
In this PR we use the walletKit rpc to query the fee instead using the  static fee estimator.
This with the addition of configuring lnd with "neutrino.feeurl"  we are able to know the fee rate in realtime.