### PR TITLE
Incremental channels rescan

### DIFF
--- a/chainservice/init.go
+++ b/chainservice/init.go
@@ -71,11 +71,10 @@ func TestPeer(peer string) error {
 	}
 
 	neutrinoConfig := neutrino.Config{
-		DataDir:       neutrinoDataDir,
-		Database:      db,
-		ChainParams:   chaincfg.MainNetParams,
-		ConnectPeers:  []string{peer},
-		PersistToDisk: true,
+		DataDir:      neutrinoDataDir,
+		Database:     db,
+		ChainParams:  chaincfg.MainNetParams,
+		ConnectPeers: []string{peer},
 	}
 	chainService, err := neutrino.NewChainService(neutrinoConfig)
 	if err != nil {
@@ -218,11 +217,10 @@ func newNeutrino(workingDir string, cfg *config.Config, peers []string) (*neutri
 		return nil, nil, err
 	}
 	neutrinoConfig := neutrino.Config{
-		DataDir:       neutrinoDataDir,
-		Database:      db,
-		ChainParams:   *params,
-		ConnectPeers:  peers,
-		PersistToDisk: true,
+		DataDir:      neutrinoDataDir,
+		Database:     db,
+		ChainParams:  *params,
+		ConnectPeers: peers,
 	}
 	logger.Infof("creating new neutrino service.")
 	chainService, err := neutrino.NewChainService(neutrinoConfig)

--- a/drophintcache/drophintcache.go
+++ b/drophintcache/drophintcache.go
@@ -19,7 +19,7 @@ func Drop(workingDir string) error {
 		return err
 	}
 
-	db, err := channeldb.Open(path.Join(workingDir, "data/chain/bitcoin/", cfg.Network, "channel.db"))
+	db, err := channeldb.Open(path.Join(workingDir, "data/graph/", cfg.Network))
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
 	google.golang.org/api v0.13.0
 	google.golang.org/grpc v1.20.1
 	gopkg.in/macaroon.v2 v2.0.0
@@ -33,8 +34,8 @@ replace (
 	github.com/btcsuite/btcwallet v0.10.0 => github.com/breez/btcwallet v0.10.1-0.20191121081139-3f579e0a038c
 	github.com/btcsuite/btcwallet/walletdb v1.1.0 => github.com/breez/btcwallet/walletdb v1.1.1-0.20191121081139-3f579e0a038c
 	github.com/btcsuite/btcwallet/wtxmgr v1.0.0 => github.com/breez/btcwallet/wtxmgr v1.0.1-0.20191121081139-3f579e0a038c
-	github.com/lightninglabs/neutrino => github.com/breez/neutrino v0.10.1-0.20191121084819-28462a8edb3a
-	github.com/lightningnetwork/lnd => github.com/breez/lnd v0.0.0-20200101072538-ad946ae712fe
+	github.com/lightninglabs/neutrino => github.com/breez/neutrino v0.10.1-0.20200116143640-44a93ea4c06a
+	github.com/lightningnetwork/lnd => github.com/breez/lnd v0.8.0-beta-rc3.0.20200116133631-c9a52c9af49a
 )
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/breez/lnd v0.8.0-beta-rc3.0.20191226115635-5c60d09842a4 h1:xIyBdK93kQ
 github.com/breez/lnd v0.8.0-beta-rc3.0.20191226115635-5c60d09842a4/go.mod h1:nq06y2BDv7vwWeMmwgB7P3pT7/Uj7sGf5FzHISVD6t4=
 github.com/breez/lnd v0.8.0-beta-rc3.0.20191231134415-ca45ec97bb31 h1:pysGVrpaPtKig2LX7tpETjCbP5IL18sypcI2ibBPPuc=
 github.com/breez/lnd v0.8.0-beta-rc3.0.20191231134415-ca45ec97bb31/go.mod h1:nq06y2BDv7vwWeMmwgB7P3pT7/Uj7sGf5FzHISVD6t4=
+github.com/breez/lnd v0.8.0-beta-rc3.0.20200116133631-c9a52c9af49a h1:w9bOxXiK5ysD2bby7HJicoWTUDhxwQA6PCEi2rpggYw=
+github.com/breez/lnd v0.8.0-beta-rc3.0.20200116133631-c9a52c9af49a/go.mod h1:nq06y2BDv7vwWeMmwgB7P3pT7/Uj7sGf5FzHISVD6t4=
 github.com/breez/neutrino v0.0.0-20190722075828-b444018978e0 h1:nSQkvsVdZP4GBURecXCaSCPg8AOQrR12j5mWpWbR1FA=
 github.com/breez/neutrino v0.0.0-20190722075828-b444018978e0/go.mod h1:vzLU75ll8qbRJIzW5dvK/UXtR9c2FecJ6VNOM8chyVM=
 github.com/breez/neutrino v0.0.0-20190911134610-a52c5cbdf335 h1:vA6MyZVCHKFdRyijR2rF2edJL223UCmty6xlPDXbATg=
@@ -96,6 +98,10 @@ github.com/breez/neutrino v0.10.1-0.20191029090218-7acdb874aa78 h1:OogFYBfD77g3z
 github.com/breez/neutrino v0.10.1-0.20191029090218-7acdb874aa78/go.mod h1:C3KhCMk1Mcx3j8v0qRVWM1Ow6rIJSvSPnUAq00ZNAfk=
 github.com/breez/neutrino v0.10.1-0.20191121084819-28462a8edb3a h1:b3Ll7sd4/9zzAC86Qk0Aa3rmmkI2TZmj88D/7led7w4=
 github.com/breez/neutrino v0.10.1-0.20191121084819-28462a8edb3a/go.mod h1:C3KhCMk1Mcx3j8v0qRVWM1Ow6rIJSvSPnUAq00ZNAfk=
+github.com/breez/neutrino v0.10.1-0.20200116110502-1631261605de h1:RUnJaWijdwQwMTutv30KJgpPMOWiaFHPyExAezdh1zc=
+github.com/breez/neutrino v0.10.1-0.20200116110502-1631261605de/go.mod h1:C3KhCMk1Mcx3j8v0qRVWM1Ow6rIJSvSPnUAq00ZNAfk=
+github.com/breez/neutrino v0.10.1-0.20200116143640-44a93ea4c06a h1:rRGipLRVmubYtPlqLUlYbtXs9oz3vALyv63kWUzcgVA=
+github.com/breez/neutrino v0.10.1-0.20200116143640-44a93ea4c06a/go.mod h1:C3KhCMk1Mcx3j8v0qRVWM1Ow6rIJSvSPnUAq00ZNAfk=
 github.com/btcsuite/btcd v0.0.0-20190629003639-c26ffa870fd8/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
@@ -342,6 +348,8 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd h1:DBH9mDw0zluJT/R+nGuV3jWFW
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR update the dependencies to support utxo scanner progress and by that allows us not to persist the filters to disk.
In addition it also fixes a bug when dropping the hint cache.