### PR TITLE
Consider pay-to-pubkey addresses as not valid.

### DIFF
--- a/account/chain.go
+++ b/account/chain.go
@@ -32,10 +32,14 @@ func (a *Service) ValidateAddress(address string) error {
 		return errors.New("unknown network type " + a.cfg.Network)
 	}
 
-	_, err := btcutil.DecodeAddress(address, network)
+	addr, err := btcutil.DecodeAddress(address, network)
 	if err != nil {
 		a.log.Errorf("Error parsing %s as address\t", address)
 		return err
+	}
+	if _, ok := addr.(*btcutil.AddressPubKey); ok {
+		a.log.Errorf("Using pay-to-pubkey address %s is considered as an error\t", address)
+		return btcutil.ErrUnknownAddressType
 	}
 
 	return nil


### PR DESCRIPTION
This kind of address is not used anymore and we need to consider them as
invalid in order to differentiate Bitcoin addresses from Lightning Network
node ids.