### PR TITLE
More robust way to wait for payment readiness

### DIFF
--- a/account/init.go
+++ b/account/init.go
@@ -29,7 +29,6 @@ type Service struct {
 	breezAPI           services.API
 	log                btclog.Logger
 	daemonAPI          lnnode.API
-	connectedNotifier  *channelActiveNotifier
 	onServiceEvent     func(data.NotificationEvent)
 	lnurlWithdrawing   string
 	activeParams       *chaincfg.Params
@@ -70,14 +69,13 @@ func NewService(
 	}
 
 	return &Service{
-		cfg:               cfg,
-		log:               logBackend.Logger("ACCNT"),
-		connectedNotifier: newChannelActiveNotifier(),
-		daemonAPI:         daemonAPI,
-		breezDB:           breezDB,
-		breezAPI:          breezAPI,
-		onServiceEvent:    onServiceEvent,
-		quitChan:          make(chan struct{}),
-		activeParams:      activeParams,
+		cfg:            cfg,
+		log:            logBackend.Logger("ACCNT"),
+		daemonAPI:      daemonAPI,
+		breezDB:        breezDB,
+		breezAPI:       breezAPI,
+		onServiceEvent: onServiceEvent,
+		quitChan:       make(chan struct{}),
+		activeParams:   activeParams,
 	}, nil
 }

--- a/account/payments.go
+++ b/account/payments.go
@@ -110,7 +110,7 @@ If the payment was failed an error is returned
 */
 func (a *Service) SendPaymentForRequest(paymentRequest string, amountSatoshi int64) error {
 	a.log.Infof("sendPaymentForRequest: amount = %v", amountSatoshi)
-	if err := a.waitChannelActive(); err != nil {
+	if err := a.waitReadyForPayment(); err != nil {
 		return err
 	}
 	lnclient := a.daemonAPI.APIClient()
@@ -130,6 +130,9 @@ func (a *Service) SendPaymentForRequest(paymentRequest string, amountSatoshi int
 
 // SendSpontaneousPayment send a payment without a payment request.
 func (a *Service) SendSpontaneousPayment(destNode string, description string, amount int64) (string, error) {
+	if err := a.waitReadyForPayment(); err != nil {
+		return "", err
+	}
 	destBytes, err := hex.DecodeString(destNode)
 	if err != nil {
 		return "", err
@@ -204,7 +207,7 @@ func (a *Service) AddInvoice(invoice *data.InvoiceMemo) (paymentRequest string, 
 	if invoice.Expiry <= 0 {
 		invoice.Expiry = defaultInvoiceExpiry
 	}
-	if err := a.waitChannelActive(); err != nil {
+	if err := a.waitReadyForPayment(); err != nil {
 		return "", err
 	}
 	channelsRes, err := lnclient.ListChannels(context.Background(), &lnrpc.ListChannelsRequest{

--- a/account/service.go
+++ b/account/service.go
@@ -71,7 +71,6 @@ func (a *Service) watchDaemonEvents() (err error) {
 				a.syncClosedChannels()
 				a.onAccountChanged()
 			case lnnode.ChannelEvent:
-				a.connectedNotifier.setActive(a.daemonAPI.HasActiveChannel())
 				if update.Type == lnrpc.ChannelEventUpdate_CLOSED_CHANNEL {
 					a.syncClosedChannels()
 				}

--- a/lnnode/daemon.go
+++ b/lnnode/daemon.go
@@ -65,6 +65,8 @@ func (d *Daemon) WaitReadyForPayment(timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
+	defer client.Cancel()
+
 	if d.IsReadyForPayment() {
 		return nil
 	}
@@ -73,7 +75,6 @@ func (d *Daemon) WaitReadyForPayment(timeout time.Duration) error {
 	timeToFinishGrace := activeGraceDuration - (time.Now().Sub(d.startTime))
 	graceTimer := time.After(timeToFinishGrace)
 	timeoutTimer := time.After(timeout)
-	defer client.Cancel()
 	for {
 		select {
 		case event := <-client.Updates():

--- a/lnnode/init.go
+++ b/lnnode/init.go
@@ -2,6 +2,7 @@ package lnnode
 
 import (
 	"sync"
+	"time"
 
 	"github.com/breez/breez/config"
 	"github.com/breez/breez/db"
@@ -24,6 +25,8 @@ import (
 type API interface {
 	SubscribeEvents() (*subscribe.Client, error)
 	HasActiveChannel() bool
+	IsReadyForPayment() bool
+	WaitReadyForPayment(timeout time.Duration) error
 	NodePubkey() string
 	APIClient() lnrpc.LightningClient
 	SubSwapClient() submarineswaprpc.SubmarineSwapperClient
@@ -41,6 +44,7 @@ type Daemon struct {
 	breezDB             *db.DB
 	started             int32
 	stopped             int32
+	startTime           time.Time
 	daemonRunning       bool
 	nodePubkey          string
 	wg                  sync.WaitGroup


### PR DESCRIPTION
This PR adds a more robust way to know when the client is ready for payment.
In multi channel environment, where some are active and some not, we need also a way to customize the timeout and add a grace period to allow all channel to become active.
I removed the connectNotifier that used a custom channel and now based totally on the daemon state and channel events.