### PR TITLE
Refactor sendPayment to run synchronously.

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -388,20 +388,24 @@ func GetPayments() ([]byte, error) {
 /*
 SendPaymentForRequest is part of the binding inteface which is delegated to breez.SendPaymentForRequest
 */
-func SendPaymentForRequest(payInvoiceRequest []byte) error {
+func SendPaymentForRequest(payInvoiceRequest []byte) ([]byte, error) {
 	decodedRequest := &data.PayInvoiceRequest{}
 	proto.Unmarshal(payInvoiceRequest, decodedRequest)
-	return getBreezApp().AccountService.SendPaymentForRequest(decodedRequest.PaymentRequest, decodedRequest.Amount)
+	traceReport, err := getBreezApp().AccountService.SendPaymentForRequest(
+		decodedRequest.PaymentRequest, decodedRequest.Amount)
+	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: err.Error()}, nil)
 }
 
 /*
 SendSpontaneousPayment is part of the binding inteface which is delegated to breez.SendSpontaneousPayment
 */
-func SendSpontaneousPayment(spontaneousPayment []byte) (string, error) {
+func SendSpontaneousPayment(spontaneousPayment []byte) ([]byte, error) {
 	decodedRequest := &data.SpontaneousPaymentRequest{}
 	proto.Unmarshal(spontaneousPayment, decodedRequest)
-	return getBreezApp().AccountService.SendSpontaneousPayment(
+	traceReport, err := getBreezApp().AccountService.SendSpontaneousPayment(
 		decodedRequest.DestNode, decodedRequest.Description, decodedRequest.Amount)
+
+	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: err.Error()}, nil)
 }
 
 //SpontaneousPaymentRequest

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -391,9 +391,14 @@ SendPaymentForRequest is part of the binding inteface which is delegated to bree
 func SendPaymentForRequest(payInvoiceRequest []byte) ([]byte, error) {
 	decodedRequest := &data.PayInvoiceRequest{}
 	proto.Unmarshal(payInvoiceRequest, decodedRequest)
+
+	var errorStr string
 	traceReport, err := getBreezApp().AccountService.SendPaymentForRequest(
 		decodedRequest.PaymentRequest, decodedRequest.Amount)
-	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: err.Error()}, nil)
+	if err != nil {
+		errorStr = err.Error()
+	}
+	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: errorStr}, nil)
 }
 
 /*
@@ -402,10 +407,15 @@ SendSpontaneousPayment is part of the binding inteface which is delegated to bre
 func SendSpontaneousPayment(spontaneousPayment []byte) ([]byte, error) {
 	decodedRequest := &data.SpontaneousPaymentRequest{}
 	proto.Unmarshal(spontaneousPayment, decodedRequest)
+
+	var errorStr string
 	traceReport, err := getBreezApp().AccountService.SendSpontaneousPayment(
 		decodedRequest.DestNode, decodedRequest.Description, decodedRequest.Amount)
 
-	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: err.Error()}, nil)
+	if err != nil {
+		errorStr = err.Error()
+	}
+	return marshalResponse(&data.PaymentResponse{TraceReport: traceReport, PaymentError: errorStr}, nil)
 }
 
 //SpontaneousPaymentRequest

--- a/swapfunds/boltzreverseswap.go
+++ b/swapfunds/boltzreverseswap.go
@@ -374,11 +374,6 @@ func (s *Service) PayReverseSwap(hash, deviceID, title, body string) error {
 		return fmt.Errorf("need to set claimFee for %v", hash)
 	}
 
-	err = s.sendPayment(rs.Invoice, rs.LnAmount)
-	if err != nil {
-		return fmt.Errorf("s.sendPayment: %v", err)
-	}
-
 	err = s.subscribeLockupScript(rs)
 	if err != nil {
 		return fmt.Errorf("s.subscribeLockupScript(%v): %w", rs, err)
@@ -386,6 +381,10 @@ func (s *Service) PayReverseSwap(hash, deviceID, title, body string) error {
 	err = s.remoteSubscribeLockupNotification(deviceID, title, body, rs.Id, rs.LockupAddress, rs.StartBlockHeight, rs.TimeoutBlockHeight)
 	if err != nil {
 		s.log.Errorf("s.remoteSubscribeLockupNotification(%v, %v, %v, %v, %v, %v): %v", deviceID, title, body, rs.Id, rs.LockupAddress, rs.StartBlockHeight, err)
+	}
+	_, err = s.sendPayment(rs.Invoice, rs.LnAmount)
+	if err != nil {
+		return fmt.Errorf("s.sendPayment: %v", err)
 	}
 	return nil
 }

--- a/swapfunds/init.go
+++ b/swapfunds/init.go
@@ -24,7 +24,7 @@ type Service struct {
 	daemonAPI        lnnode.API
 	breezAPI         services.API
 	chainParams      *chaincfg.Params
-	sendPayment      func(payreq string, amount int64) error
+	sendPayment      func(payreq string, amount int64) (string, error)
 	getAccountLimits func() (maxReceive, maxPay, maxReserve int64, err error)
 	onServiceEvent   func(data.NotificationEvent)
 	quitChan         chan struct{}
@@ -35,7 +35,7 @@ func NewService(
 	breezDB *db.DB,
 	breezAPI services.API,
 	daemonAPI lnnode.API,
-	sendPayment func(payreq string, amount int64) error,
+	sendPayment func(payreq string, amount int64) (string, error),
 	getAccountLimits func() (maxReceive, maxPay, maxReserve int64, err error),
 	onServiceEvent func(data.NotificationEvent)) (*Service, error) {
 

--- a/swapfunds/removefunds.go
+++ b/swapfunds/removefunds.go
@@ -39,7 +39,7 @@ func (s *Service) RemoveFund(amount int64, address string) (*data.RemoveFundRepl
 	s.breezDB.AddRedeemablePaymentHash(payreq.PaymentHash)
 
 	s.log.Infof("RemoveFunds: Sending payment...")
-	err = s.sendPayment(reply.PaymentRequest, 0)
+	_, err = s.sendPayment(reply.PaymentRequest, 0)
 	if err != nil {
 		s.log.Errorf("SendPaymentForRequest failed: %v", err)
 		return nil, err


### PR DESCRIPTION
This PR simplifies the send payment API for both spontaneous and with payment request.
Instead of getting the result asynchronously the result is returned synchronously and includes the trace report.
Only for those pending payments that are found after restart an event is sent with their result in order for the UI to be able to respond.