### PR TITLE
support lnurl fallback scheme.

### DIFF
--- a/account/lnurl.go
+++ b/account/lnurl.go
@@ -3,6 +3,7 @@ package account
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 
@@ -10,7 +11,12 @@ import (
 	"github.com/fiatjaf/go-lnurl"
 )
 
-func (a *Service) HandleLNURL(encodedLnurl string) (*data.LNUrlResponse, error) {
+func (a *Service) HandleLNURL(rawString string) (*data.LNUrlResponse, error) {
+	encodedLnurl, ok := lnurl.FindLNURLInText(rawString)
+	if !ok {
+		return nil, fmt.Errorf("'%s' does not contain an LNURL.", rawString)
+	}
+
 	a.log.Infof("HandleLNURL %v", encodedLnurl)
 	iparams, err := lnurl.HandleLNURL(encodedLnurl)
 	if err != nil {


### PR DESCRIPTION
I think this does it, still puzzled by the Flutter side though.

But if the Flutter side is sending anything it gets from the QR code scan directly through the Go backend then this should do it.