### PR TITLE
Return error when no routing hints.

### DIFF
--- a/account/payments.go
+++ b/account/payments.go
@@ -352,6 +352,10 @@ func (a *Service) AddInvoice(invoiceRequest *data.AddInvoiceRequest) (paymentReq
 		}
 	}
 
+	if len(routingHints) == 0 {
+		return "", 0, errors.New("no routing information")
+	}
+
 	// create invoice with the lower amount.
 	response, err := lnclient.AddInvoice(context.Background(), &lnrpc.Invoice{
 		RPreimage: invoice.Preimage,


### PR DESCRIPTION
This change is to return error when invoice is about to be created with no routing hints since it won't be usable anyway.