### PR TITLE
Adding build info to the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 In order to build breez you will need to install [gomobile](https://github.com/golang/go/wiki/Mobile) and go 1.13.4.
 ## Prepare your environment
 ```
-git clone https://github.com/breez/breez.git gopath/src/github.com/breez/breez
-export GOPATH=$(pwd)/gopath
-GO111MODULE=off go get golang.org/x/mobile/cmd/gomobile
-GO111MODULE=off go get golang.org/x/mobile/cmd/gobind
-$GOPATH/bin/gomobile init
-cd gopath/src/github.com/breez/breez
-go mod vendor
+git clone https://github.com/breez/breez.git
+go get -d golang.org/x/mobile/cmd/gomobile
+go get -d golang.org/x/mobile/cmd/gobind
 export PATH=$PATH:$GOPATH/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ git clone https://github.com/breez/breez.git
 go get -d golang.org/x/mobile/cmd/gomobile
 go get -d golang.org/x/mobile/cmd/gobind
 export PATH=$PATH:$GOPATH/bin
+gomobile init
 ```
 
 ## Building `breez` for Android

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ GO111MODULE=off go get golang.org/x/mobile/cmd/gobind
 $GOPATH/bin/gomobile init
 cd gopath/src/github.com/breez/breez
 go mod vendor
+export PATH=$PATH:$GOPATH/bin
 ```
+
 ## Building `breez` for Android
 You need to install the ndk as part of your sdk Tools.
 If you have a separate ndk installed then make sure to set the ANDROID_NDK_HOME environment variable to your ndk install location.


### PR DESCRIPTION
Fixed #132

I try to build the project and I found this information missing inside the readme.

Without this, an env configured with the modern go lang project format is unable to build the target.