### PR TITLE
GoMobile broke framework creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # breez
-In order to build breez you will need to install [gomobile](https://github.com/golang/go/wiki/Mobile) and go 1.13.4.
+In order to build breez you will need to install [gomobile](https://github.com/golang/go/wiki/Mobile) and go 1.13.4. If you install go from homebrew, you will have to ensure the GOPATH environment variable is set yourself.
 ## Prepare your environment
 ```
 git clone https://github.com/breez/breez.git

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -3,4 +3,4 @@
 
 #export GO111MODULE=off
 mkdir -p build/ios
-PATH=$PATH:$GOPATH/bin gomobile bind -target=ios/arm64 -tags="ios experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" -o build/ios/bindings.framework -ldflags="-s -w" github.com/breez/breez/bindings
+PATH=$PATH:$GOPATH/bin gomobile bind -target=ios -tags="ios experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" -o build/ios/bindings.xcframework -ldflags="-s -w" github.com/breez/breez/bindings


### PR DESCRIPTION
This PR addresses Issue #137 
GoMobile updated to 100% of the time build xcframeworks instead of fat frameworks.

GoMobile will no longer pay attention to architectures that are passed in.
In addition, it is enforcing that the framework extension be .xcframework.

Added an extra note to the README warning about installing Go from Homebrew.