### PR TITLE
Tor hotfix

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,14 +48,7 @@ func (a *App) Start(torConfig *data.TorConfig) error {
 
 	useTor, _ := a.breezDB.GetTorActive()
 	a.log.Infof("OS is %v", runtime.GOOS)
-	if runtime.GOOS == "android" && useTor {
-		if torConfig == nil {
-			err := errors.New("app.go: start: tor is enabled but a configuration was not found.")
-			a.log.Errorf("app.go: starting breez without tor: %v", err)
-			a.breezDB.SetTorActive(false)
-			return err
-		}
-
+	if runtime.GOOS == "android" && useTor && torConfig != nil {
 		a.log.Infof("app.Start: useTor = %v, torConfig = %+v.", useTor, *torConfig)
 		_torConfig := &tor.TorConfig{
 			Socks:   torConfig.Socks,
@@ -63,34 +56,11 @@ func (a *App) Start(torConfig *data.TorConfig) error {
 			Control: torConfig.Control,
 		}
 
-		/* The current backup provider has a pointer to a torConfig
-		but if torConfig was nil, then setting a.BackupManager.TorConfig
-		will only affect newly created backup providers. Therefore, we
-		reset the current backup provider's torConfig pointer here.
-		*/
-		provider := a.BackupManager.GetProvider()
-		provider.SetTor(_torConfig)
-		a.BackupManager.SetProvider(provider)
-
 		chainservice.SetTor(_torConfig, true)
-
 		a.BackupManager.TorConfig = _torConfig
 		a.lnDaemon.TorConfig = _torConfig
 		a.AccountService.TorConfig = _torConfig
 
-	} else {
-		a.log.Info("app.Start: starting without Tor.")
-
-		a.lnDaemon.TorConfig = nil
-
-		chainservice.SetTor(nil, false)
-
-		a.BackupManager.TorConfig = nil
-		provider := a.BackupManager.GetProvider()
-		provider.SetTor(nil)
-		a.BackupManager.SetProvider(provider)
-
-		a.AccountService.TorConfig = nil
 	}
 
 	a.log.Info("app.start: starting services.")

--- a/app.go
+++ b/app.go
@@ -57,7 +57,7 @@ func (a *App) Start(torConfig *data.TorConfig) error {
 		}
 
 		chainservice.SetTor(_torConfig, true)
-		a.BackupManager.TorConfig = _torConfig
+		a.BackupManager.SetTorConfig(_torConfig)
 		a.lnDaemon.TorConfig = _torConfig
 		a.AccountService.TorConfig = _torConfig
 

--- a/backup/init.go
+++ b/backup/init.go
@@ -64,7 +64,7 @@ type Manager struct {
 	mu                sync.Mutex
 	wg                sync.WaitGroup
 
-	TorConfig *tor.TorConfig
+	torConfig *tor.TorConfig
 }
 
 // NewManager creates a new Manager

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -568,6 +568,7 @@ func (b *Manager) SetBackupProvider(providerName, authData string) error {
 	if err != nil {
 		return err
 	}
+	provider.SetTor(b.TorConfig)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.provider = provider

--- a/backup/manager.go
+++ b/backup/manager.go
@@ -548,27 +548,20 @@ func (b *Manager) getBackupIdentifier() (string, error) {
 	return "backup-id-" + hex.EncodeToString(id), nil
 }
 
-func (b *Manager) SetTorConfig(torConfig *data.TorConfig) {
-	if torConfig != nil {
-		config := &tor.TorConfig{
-			Socks:   torConfig.Socks,
-			Http:    torConfig.Http,
-			Control: torConfig.Control,
-		}
-		b.TorConfig = config
-		if b.provider != nil {
-			b.provider.SetTor(config)
-		}
+func (b *Manager) SetTorConfig(torConfig *tor.TorConfig) {
+	b.torConfig = torConfig
+	if b.provider != nil {
+		b.provider.SetTor(b.torConfig)
 	}
 }
 
 func (b *Manager) SetBackupProvider(providerName, authData string) error {
 	b.log.Infof("setting backup provider %v", providerName)
-	provider, err := createBackupProvider(providerName, ProviderFactoryInfo{b.authService, authData, b.log, b.TorConfig})
+	provider, err := createBackupProvider(providerName, ProviderFactoryInfo{b.authService, authData, b.log, b.torConfig})
 	if err != nil {
 		return err
 	}
-	provider.SetTor(b.TorConfig)
+	provider.SetTor(b.torConfig)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.provider = provider

--- a/bindings/api.go
+++ b/bindings/api.go
@@ -179,15 +179,6 @@ func SetBackupEncryptionKey(key []byte, encryptionType string) error {
 	return getBreezApp().BackupManager.SetEncryptionKey(encKey, encryptionType)
 }
 
-func SetBackupTorConfig(torConfig []byte) error {
-	_torConfig := &data.TorConfig{}
-	if err := proto.Unmarshal(torConfig, _torConfig); err != nil {
-		return err
-	}
-	getBreezApp().BackupManager.SetTorConfig(_torConfig)
-	return nil
-}
-
 /*
 Start the lightning client
 */


### PR DESCRIPTION
Fixes bug that causes iOS and Android to crash on fresh install. 

The issue where caused by trying to set backupmanagen on an empty provider.


Removed _SetBackupTorConfig_ from the bridge