### PR TITLE
doc: Recommend go install rather than go get -d, and bump to go 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ In order to build breez you will need to install [gomobile](https://github.com/g
 ## Prepare your environment
 ```
 git clone https://github.com/breez/breez.git
-go get -d golang.org/x/mobile/cmd/gomobile
-go get -d golang.org/x/mobile/cmd/gobind
+go install golang.org/x/mobile/cmd/gomobile
+go install golang.org/x/mobile/cmd/gobind
 export PATH=$PATH:$GOPATH/bin
 gomobile init
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # breez
-In order to build breez you will need to install [gomobile](https://github.com/golang/go/wiki/Mobile) and [go 1.16.x](https://go.dev/dl/). If you install go from homebrew, you will have to ensure the GOPATH environment variable is set yourself.
+In order to build breez you will need to install [gomobile](https://github.com/golang/go/wiki/Mobile) and [go 1.17.x](https://go.dev/dl/). If you install go from homebrew, you will have to ensure the GOPATH environment variable is set yourself.
 ## Prepare your environment
 ```
 git clone https://github.com/breez/breez.git

--- a/docker/alice/Dockerfile
+++ b/docker/alice/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.12 AS builder
+FROM golang:1.17-alpine3.16 AS builder
 RUN apk update
 RUN apk add git go musl-dev make bash
 RUN export tags="experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc"

--- a/docker/breez_server/Dockerfile
+++ b/docker/breez_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.12 AS builder
+FROM golang:1.17-alpine3.16 AS builder
 RUN apk update
 RUN apk add git go musl-dev make
 COPY ./docker/breez_server/.env .

--- a/docker/lspd/Dockerfile
+++ b/docker/lspd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.12 AS builder
+FROM golang:1.17-alpine3.16 AS builder
 RUN apk update
 RUN apk add git go musl-dev make
 COPY ./docker/lspd/.env .


### PR DESCRIPTION
As recorded in the docs, go get -d does not install the binary which is
required in the next step. From `go help get`:

> The -d flag instructs get not to build or install packages. get will only
update go.mod and download source code needed to build packages.

> Building and installing packages with get is deprecated. In a future release,
the -d flag will be enabled by default, and 'go get' will be only be used to
adjust dependencies of the current module. To install a package using
dependencies from the current module, use 'go install'. To install a package
ignoring the current module, use 'go install' with an @Version suffix like
"@latest" after each argument.

[Note](https://github.com/breez/breez/pull/179#issuecomment-1430835571): running `go install golang.org/x/mobile/cmd/gomobile` under 1.17 does not prompt for additional dependencies, and does successfully build