### PR TITLE
Await htlc resolution

### DIFF
--- a/channeldbservice/init.go
+++ b/channeldbservice/init.go
@@ -119,6 +119,7 @@ func createService(workingDir string) (*channeldb.DB, error) {
 
 	logger.Infof("creating shared channeldb service.")
 	cfg := lnd.DefaultConfig()
+	cfg.StoreFinalHtlcResolutions = true
 	dbOptions := []channeldb.OptionModifier{
 		channeldb.OptionSetRejectCacheSize(cfg.Caches.RejectCacheSize),
 		channeldb.OptionSetChannelCacheSize(cfg.Caches.ChannelCacheSize),
@@ -128,6 +129,7 @@ func createService(workingDir string) (*channeldb.DB, error) {
 		channeldb.OptionKeepFailedPaymentAttempts(cfg.KeepFailedPaymentAttempts),
 		channeldb.OptionPruneRevocationLog(cfg.DB.PruneRevocation),
 		channeldb.OptionSetPreAllocCacheNumNodes(channeldb.DefaultPreAllocCacheNumNodes),
+		channeldb.OptionStoreFinalHtlcResolutions(cfg.StoreFinalHtlcResolutions),
 	}
 
 	opts := channeldb.DefaultOptions()

--- a/lnnode/daemon.go
+++ b/lnnode/daemon.go
@@ -332,6 +332,7 @@ func (d *Daemon) createConfig(workingDir string, torConfig *tor.TorConfig, inter
 	cfg.LogWriter = writer
 	cfg.MinBackoff = time.Second * 20
 	cfg.TLSDisableAutofill = true
+	cfg.StoreFinalHtlcResolutions = true
 
 	fileParser := flags.NewParser(&cfg, flags.IgnoreUnknown)
 	err = flags.NewIniParser(fileParser).ParseFile(lndConfig.ConfigFile)


### PR DESCRIPTION
This PR in the current form makes sure the INVOICE_PAID event is not fired until the underlying htlcs are settled (the commitments containing the htlcs are revoked). The hope is that users would wait with closing the app until they see a checkmark. So delaying the checkmark until the htlcs are finally settled could avoid some force closes.

In order to do that we need to use the new `LookupHtlc` api, which will be added in LND 0.16. So this PR will be dependent on LND releasing the 0.16 version. For this draft PR I've rebased breez/lnd on top of lightningnetwork/lnd@master temporarily. It can be found as this temporary branch: https://github.com/breez/lnd/tree/temp-lnd-merge-0.16 . Upgrading that depends on a later version of btcwallet. So also breez/btcd is updated in a temporary branch: https://github.com/breez/btcwallet/tree/temp-breez-merge-0.16.6 

In order to use `LookupHtlc`, the final outcome of htlcs has to be stored by LND, which is done with the `StoreFinalHtlcResolutions` flag.

The described procedure from [this PR](https://github.com/lightningnetwork/lnd/pull/6517#issue-1229844699) is followed to wait for the htlcs to be finalized.

Fixes https://github.com/breez/breez/issues/175

This does not fix htlc finalization forgood. It does not fix the same problem for sending payments for example. Also it could be a good idea to store any pending htlcs in a separate database so that when the chain is being synced, also the node could come online to if there are any pending htlcs, so they can be settled offchain.