### PR TITLE
Backup node data even if only app data is requested.

### DIFF
--- a/backup/manager.go
+++ b/backup/manager.go
@@ -273,13 +273,10 @@ func (b *Manager) Start() error {
 				var err error
 				var accountName string
 
-				if req.BackupNodeData {
-					b.log.Infof("starting backup node data")
-					if accountName, err = b.processBackupRequest(true); err != nil {
-						b.log.Errorf("failed to process backup request: %v", err)
-						b.notifyBackupFailed(err)
-						continue
-					}
+				if accountName, err = b.processBackupRequest(true); err != nil {
+					b.log.Errorf("failed to process backup request: %v", err)
+					b.notifyBackupFailed(err)
+					continue
 				}
 				if req.BackupAppData {
 					b.log.Infof("starting backup app data")


### PR DESCRIPTION
This PR adds some safty mechanism to always backup the node data even if only app data backup is requested.
This is to make sure the snapshot in the cloud always contains some state of the node data and remove the risk of users 
 ignoring the warning icon and forgetting to backup at some point in the future.