### PR TITLE
refresh lsp list on every call

### DIFF
--- a/bindings/api.go
+++ b/bindings/api.go
@@ -772,8 +772,9 @@ func LSPActivity() ([]byte, error) {
 	mu.Lock()
 	lspList = cachedLSPList
 	mu.Unlock()
+	var err error
 	if lspList == nil {
-		lspList, err := getBreezApp().ServicesClient.LSPList()
+		lspList, err = getBreezApp().ServicesClient.LSPList()
 		if err != nil {
 			return nil, err
 		}

--- a/services/client.go
+++ b/services/client.go
@@ -160,11 +160,6 @@ func (c *Client) ReceiverNode() (string, error) {
 // LSPList returns the list of the LSPs
 func (c *Client) LSPList() (*data.LSPList, error) {
 	con := c.getBreezClientConnection()
-	c.Lock()
-	defer c.Unlock()
-	if c.lspList != nil {
-		return c.lspList, nil
-	}
 	ctx, cancel := context.WithTimeout(
 		metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+c.cfg.LspToken),
 		endpointTimeout*time.Second,
@@ -226,8 +221,8 @@ func (c *Client) LSPList() (*data.LSPList, error) {
 		lspInfo.LongestValidOpeningFeeParams = longestParams
 		r[id] = lspInfo
 	}
-	c.lspList = &data.LSPList{Lsps: r}
-	return c.lspList, nil
+
+	return &data.LSPList{Lsps: r}, nil
 }
 
 func (c *Client) getCheapestOpeningFeeParams(menu []*data.OpeningFeeParams) *data.OpeningFeeParams {

--- a/services/init.go
+++ b/services/init.go
@@ -35,7 +35,6 @@ type Client struct {
 	cfg        *config.Config
 	log        btclog.Logger
 	connection *grpc.ClientConn
-	lspList    *data.LSPList
 }
 
 // NewClient creates a new client struct


### PR DESCRIPTION
Removed the caching of lsp list.
Added caching on one function that relied on the old caching behavior. It only uses the lsp ids and my concern of removing the caching here will cause some performance regressions on breez mobile.
We might decide on higher level to call it less frequently and then we may remove the caching here as well.