### PR TITLE
Fix broken simnet

### DIFF
--- a/docker/dev-simnet.yml
+++ b/docker/dev-simnet.yml
@@ -118,6 +118,7 @@ services:
       nodes:
         ipv4_address: 10.5.0.9
     environment:
+      MEMPOOL_API_BASE_URL: ${MEMPOOL_API_BASE_URL}
       NODE_HOST: ${DEV_HOST_IP}:9736
       NODE_PUBKEY: ${NODE_PUBKEY}
   dev-postgres:

--- a/docker/lspd/start.sh
+++ b/docker/lspd/start.sh
@@ -1,4 +1,6 @@
 /go/bin/migrate   -source file:///go/lspd/postgresql/migrations/ --database postgres://postgres:test@10.5.0.8:5432/postgres?sslmode=disable up 100
+
+echo "MEMPOOL_API_BASE_URL=$MEMPOOL_API_BASE_URL"
 echo "NODE_PUBKEY=$NODE_PUBKEY"
 echo "NODE_HOST=$NODE_HOST"
 ./generate_lspd_config 10.5.0.3:10009 /root/breez_node/data/chain/bitcoin/simnet/admin.macaroon /root/breez_node/tls.cert $NODE_PUBKEY $NODE_HOST >> .env

--- a/docker/lspd/start.sh
+++ b/docker/lspd/start.sh
@@ -1,4 +1,4 @@
-/go/bin/migrate   -source file:///go/lspd/postgresql/migrations/ --database postgres://postgres:test@10.5.0.8:5432/postgres?sslmode=disable up 10
+/go/bin/migrate   -source file:///go/lspd/postgresql/migrations/ --database postgres://postgres:test@10.5.0.8:5432/postgres?sslmode=disable up 100
 echo "NODE_PUBKEY=$NODE_PUBKEY"
 echo "NODE_HOST=$NODE_HOST"
 ./generate_lspd_config 10.5.0.3:10009 /root/breez_node/data/chain/bitcoin/simnet/admin.macaroon /root/breez_node/tls.cert $NODE_PUBKEY $NODE_HOST >> .env

--- a/docker/simnet.yml
+++ b/docker/simnet.yml
@@ -149,6 +149,7 @@ services:
       context: ../
       dockerfile: docker/lspd/Dockerfile
     environment:
+      MEMPOOL_API_BASE_URL: ${MEMPOOL_API_BASE_URL}
       NODE_HOST: 10.5.0.3
       NODE_PUBKEY: ${NODE_PUBKEY}
     volumes:

--- a/docker/start-dev-env.sh
+++ b/docker/start-dev-env.sh
@@ -1,5 +1,6 @@
 export DEV_HOST_IP=127.0.0.1
 export TEST_DIR=/Users/roeierez/test/docker
+export MEMPOOL_API_BASE_URL=https://mempool.space/api/v1/
 
 export ALICE_BREEZ_ADDRESS="127.0.0.1:50053"
 export ALICE_DIR=$TEST_DIR/alice_node

--- a/docker/start-network.sh
+++ b/docker/start-network.sh
@@ -1,3 +1,5 @@
+export MEMPOOL_API_BASE_URL=https://mempool.space/api/v1/
+
 export ALICE_BREEZ_ADDRESS="127.0.0.1:50053"
 export ALICE_DIR=$TEST_DIR/alice_node
 export ALICE_LND_ADDRESS="127.0.0.1:10009"


### PR DESCRIPTION
Hey again, the simnet broke again due to recent changes as detailed here: https://github.com/breez/breez/issues/184#issuecomment-1566170899

These are my fixes for the LSPD migrations not being applied and the MEMPOOL_API_BASE_URL not being set. Let me know if any changes are required, I figured the normal mempool API is probably fine however it should be possible to include a local mempool instance in the future: https://github.com/mempool/mempool/tree/master/docker