### PR TITLE
set minimum android api for gomobile

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 # gomobile & gobind needs to be installed in $GOPATH/bin
 
 mkdir -p build/android
-gomobile bind -target=android -tags="android experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" -o build/android/breez.aar github.com/breez/breez/bindings
+gomobile bind -target=android -androidapi=19 -tags="android experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" -o build/android/breez.aar github.com/breez/breez/bindings


### PR DESCRIPTION
Fixes this error:
`gomobile: ANDROID_NDK_HOME specifies /path/to/ndk/25.2.9519653, which is unusable: unsupported API version 16 (not in 19..33)`