### PR TITLE
fix simnet env by pointing to specific versions

### DIFF
--- a/docker/alice/Dockerfile
+++ b/docker/alice/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest AS builder
 RUN apk update
 RUN apk add git go musl-dev make bash
 RUN export tags="experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc"
-RUN git clone https://github.com/lightningnetwork/lnd
+RUN git clone --depth 1 --branch lnd-merge-0.16.4 https://github.com/breez/lnd
 ENV tags="experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc"
 ENV DEV_TAGS="experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc"
 RUN cd lnd && tags="experimental signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" && make install

--- a/docker/breez/Dockerfile
+++ b/docker/breez/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest AS builder
 RUN apk update
 RUN apk add git go musl-dev make
-RUN git clone https://github.com/breez/lnd -b breez-node
+RUN git clone --depth 1 --branch breez-node-v0.16.4-beta https://github.com/breez/lnd
 
 RUN cd lnd \
     && go build -tags=experimental,invoicesrpc,signrpc,autopilotrpc,experimental,submarineswaprpc,chanreservedynamic,routerrpc,walletrpc,chainrpc ./cmd/lnd/ \

--- a/docker/breez_server/Dockerfile
+++ b/docker/breez_server/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/breez/server
 RUN cd server \
     && go build .
 RUN go install github.com/joho/godotenv/cmd/godotenv@latest
-RUN git clone https://github.com/breez/lnd -b breez-node
+RUN git clone --depth 1 --branch breez-node-v0.16.4-beta https://github.com/breez/lnd
 RUN cd lnd \
     && tags="signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" \
     && make install

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest AS builder
 RUN apk update
 RUN apk add git go musl-dev make bash
-RUN git clone https://github.com/breez/lnd
+RUN git clone --depth 1 --branch v0.16.4-beta https://github.com/lightningnetwork/lnd
 
 RUN cd lnd \
-    && go build -tags=experimental,invoicesrpc,signrpc,autopilotrpc,experimental,submarineswaprpc,chanreservedynamic,routerrpc,walletrpc,chainrpc ./cmd/lnd/ \
-    && go build -tags=experimental,invoicesrpc,signrpc,autopilotrpc,experimental,submarineswaprpc,chanreservedynamic,routerrpc,walletrpc,chainrpc ./cmd/lncli/
+    && go build -tags=experimental,invoicesrpc,signrpc,autopilotrpc,routerrpc,walletrpc,chainrpc ./cmd/lnd/ \
+    && go build -tags=experimental,invoicesrpc,signrpc,autopilotrpc,routerrpc,walletrpc,chainrpc ./cmd/lncli/
 
 VOLUME /root/.lnd
 EXPOSE 10013 9739

--- a/docker/lspd/Dockerfile
+++ b/docker/lspd/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:latest AS builder
-COPY ./docker/lspd/.env .
+COPY ./docker/lspd/.env.template .
 COPY ./docker/lspd/start.sh .
 RUN chmod +x ./start.sh
 RUN git clone https://github.com/breez/lspd
@@ -8,7 +8,7 @@ RUN cd lspd \
     && go build .
 RUN go install github.com/joho/godotenv/cmd/godotenv@latest
 
-RUN git clone https://github.com/breez/lnd -b breez-node
+RUN git clone https://github.com/breez/lnd -b breez-node-v0.16.4-beta
 RUN cd lnd \
     && tags="signrpc walletrpc chainrpc invoicesrpc routerrpc backuprpc peerrpc submarineswaprpc breezbackuprpc" \
     && make install

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/breez/boltz v0.0.0-20230529122619-7972e1f7a7b7
-	github.com/breez/lspd v0.0.0-20230216140105-14f93d934eb1
+	github.com/breez/lspd v0.0.0-20230630175015-34646d50a591
 	github.com/btcsuite/btcd v0.23.5-0.20230228185050-38331963bddd
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.3
@@ -170,7 +170,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
-	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6 h1:wKdLeI
 github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6/go.mod h1:TQVDhFxseiGtZwEPvLgtfyxuNUDsIdaJdshvWzR0HJ4=
 github.com/breez/lnd v0.16.4-beta-breez h1:nIizHySYiximOpBbYorCSUwqEAZRANYmVhoa0syKM+o=
 github.com/breez/lnd v0.16.4-beta-breez/go.mod h1:o9fS8yy79RDcLlZLBhea82OpIRPsofsmXhCJcP8nrYY=
-github.com/breez/lspd v0.0.0-20230216140105-14f93d934eb1 h1:YeNozvjzg1+hmzVkEsAVeJQFvDS152Z8bsuWchOgaTM=
-github.com/breez/lspd v0.0.0-20230216140105-14f93d934eb1/go.mod h1:b/gOqsUBpr0JwQmv6aKLZk36QcGoAoNVffKLwk9Sneg=
+github.com/breez/lspd v0.0.0-20230630175015-34646d50a591 h1:vSyn3d0GOlNWUaWtRtSwjwIS8+3qLLirVWN+flQOt3I=
+github.com/breez/lspd v0.0.0-20230630175015-34646d50a591/go.mod h1:sziWG8CyL2rBHr7d6ncxFiK2R3f18SRtOEcFeP7Rvz4=
 github.com/breez/neutrino v0.15.0-breez h1:thAtS07C67HSO7OQAa6uX32Eig7E6BQ06KzGeiy/N4g=
 github.com/breez/neutrino v0.15.0-breez/go.mod h1:pmjwElN/091TErtSE9Vd5W4hpxoG2/+xlb+HoPm9Gug=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
@@ -845,6 +845,8 @@ golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5/go.mod h1:lgLbSvA5ygNOMpwM/9
 golang.org/x/exp v0.0.0-20221111094246-ab4555d3164f/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 h1:OvjRkcNHnf6/W5FZXSxODbxwD+X7fspczG7Jn/xQVD4=
 golang.org/x/exp v0.0.0-20221212164502-fae10dda9338/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/itest/generate_lspd_config.go
+++ b/itest/generate_lspd_config.go
@@ -8,41 +8,9 @@ import (
 	"log"
 	"os"
 
+	"github.com/breez/lspd/config"
 	"github.com/btcsuite/btcd/btcec/v2"
 )
-
-type NodeConfig struct {
-	Name                      string     `json:name,omitempty`
-	NodePubkey                string     `json:nodePubkey,omitempty`
-	LspdPrivateKey            string     `json:"lspdPrivateKey"`
-	Tokens                    []string   `json:"tokens"`
-	Host                      string     `json:"host"`
-	PublicChannelAmount       int64      `json:"publicChannelAmount,string"`
-	ChannelAmount             uint64     `json:"channelAmount,string"`
-	ChannelPrivate            bool       `json:"channelPrivate"`
-	TargetConf                uint32     `json:"targetConf,string"`
-	MinHtlcMsat               uint64     `json:"minHtlcMsat,string"`
-	BaseFeeMsat               uint64     `json:"baseFeeMsat,string"`
-	FeeRate                   float64    `json:"feeRate,string"`
-	TimeLockDelta             uint32     `json:"timeLockDelta,string"`
-	ChannelFeePermyriad       int64      `json:"channelFeePermyriad,string"`
-	ChannelMinimumFeeMsat     int64      `json:"channelMinimumFeeMsat,string"`
-	AdditionalChannelCapacity int64      `json:"additionalChannelCapacity,string"`
-	MaxInactiveDuration       uint64     `json:"maxInactiveDuration,string"`
-	Lnd                       *LndConfig `json:"lnd,omitempty"`
-	Cln                       *ClnConfig `json:"cln,omitempty"`
-}
-
-type LndConfig struct {
-	Address  string `json:"address"`
-	Cert     string `json:"cert"`
-	Macaroon string `json:"macaroon"`
-}
-
-type ClnConfig struct {
-	PluginAddress string `json:"pluginAddress"`
-	SocketPath    string `json:"socketPath"`
-}
 
 func main() {
 	address := os.Args[1]
@@ -63,7 +31,7 @@ func main() {
 	}
 	key := hex.EncodeToString(p.Serialize())
 
-	config := NodeConfig{
+	cfg := config.NodeConfig{
 		LspdPrivateKey:            key,
 		Host:                      nodeHost,
 		NodePubkey:                nodePubKey,
@@ -76,11 +44,11 @@ func main() {
 		TimeLockDelta:             144,
 		Tokens:                    []string{"8qFbOxF8K8frgrhNE/Hq/UkUlq7A1Qvh8um1VdCUv2L4es/RXEe500E+FAKkLI4X"},
 	}
-	config.Lnd = &LndConfig{
+	cfg.Lnd = &config.LndConfig{
 		Address:  address,
 		Cert:     string(textCert),
 		Macaroon: macHexa,
 	}
-	json, _ := json.Marshal([]NodeConfig{config})
+	json, _ := json.Marshal([]config.NodeConfig{cfg})
 	fmt.Printf(fmt.Sprintf("\nNODES='%v'\n", string(json)))
 }

--- a/itest/tests/open_channel_compat_test.go
+++ b/itest/tests/open_channel_compat_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
-func Test_open_channel_competability(t *testing.T) {
-	t.Logf("Testing Test_open_channel_competability")
+func Test_open_channel_compatibility(t *testing.T) {
+	t.Logf("Testing Test_open_channel_compatibility")
 	test := newTestFramework(t)
 	lndClient := lnrpc.NewLightningClient(test.lndNode)
 	bobClient := lnrpc.NewLightningClient(test.bobNode)

--- a/itest/tests/subswap_test.go
+++ b/itest/tests/subswap_test.go
@@ -58,6 +58,7 @@ func TestSubswap(t *testing.T) {
 		&data.AddFundInitRequest{
 			NotificationToken: "testtoken",
 			LspID:             "lspd-secret",
+			OpeningFeeParams:  list.Lsps["lspd-secret"].LongestValidOpeningFeeParams,
 		})
 	if err != nil {
 		t.Fatalf("error in AddFundInit %v", err)


### PR DESCRIPTION
All dockerfiles for the simnet environment now point to the right repository and to a specific version of that repository. That means if a version is updated, we should update the versions in the dockerfiles here as well.

Small extras:
- Fixed a bug with the lspd .env file
- Use opening_fee_params in the subswap test

Should fix https://github.com/breez/breez/issues/214