### PR TITLE
bump lnd version to v0.16.4-breez-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,5 +203,5 @@ replace (
 	github.com/btcsuite/btcwallet/walletdb => github.com/breez/btcwallet/walletdb v1.4.0-breez
 	github.com/btcsuite/btcwallet/wtxmgr => github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6
 	github.com/lightninglabs/neutrino => github.com/breez/neutrino v0.15.0-breez
-	github.com/lightningnetwork/lnd => github.com/breez/lnd v0.16.4-beta-breez
+	github.com/lightningnetwork/lnd => github.com/breez/lnd v0.16.4-breez-2
 )

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/breez/btcwallet/walletdb v1.4.0-breez h1:Ukwi/c4iO2qhQbjQkrz6ieBLqf9K
 github.com/breez/btcwallet/walletdb v1.4.0-breez/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
 github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6 h1:wKdLeIJung+re0vLW+nmOc8tS5lfA9WMwDlog+JzQzI=
 github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6/go.mod h1:TQVDhFxseiGtZwEPvLgtfyxuNUDsIdaJdshvWzR0HJ4=
-github.com/breez/lnd v0.16.4-beta-breez h1:nIizHySYiximOpBbYorCSUwqEAZRANYmVhoa0syKM+o=
-github.com/breez/lnd v0.16.4-beta-breez/go.mod h1:o9fS8yy79RDcLlZLBhea82OpIRPsofsmXhCJcP8nrYY=
+github.com/breez/lnd v0.16.4-breez-2 h1:zdLZMKA/QCH4vts179E5noO1WBb1hD54/pdRM9CW1TA=
+github.com/breez/lnd v0.16.4-breez-2/go.mod h1:o9fS8yy79RDcLlZLBhea82OpIRPsofsmXhCJcP8nrYY=
 github.com/breez/lspd v0.0.0-20230630175015-34646d50a591 h1:vSyn3d0GOlNWUaWtRtSwjwIS8+3qLLirVWN+flQOt3I=
 github.com/breez/lspd v0.0.0-20230630175015-34646d50a591/go.mod h1:sziWG8CyL2rBHr7d6ncxFiK2R3f18SRtOEcFeP7Rvz4=
 github.com/breez/neutrino v0.15.0-breez h1:thAtS07C67HSO7OQAa6uX32Eig7E6BQ06KzGeiy/N4g=


### PR DESCRIPTION
This version of LND contains a potential fix for clients where the channel graph is corrupted due to an invalid channel key.