### PR TITLE
Use the real channel blockheight for rescans

### DIFF
--- a/sync/channelswatcher.go
+++ b/sync/channelswatcher.go
@@ -77,7 +77,12 @@ func NewChannelsWatcher(
 		}
 
 		log.Infof("watching channel id: %v", c.ShortChannelID.String())
-		channelBlockHeight := uint64(c.ShortChannelID.BlockHeight)
+		var channelBlockHeight uint64
+		if c.IsZeroConf() {
+			channelBlockHeight = uint64(c.ZeroConfRealScid().BlockHeight)
+		} else {
+			channelBlockHeight = uint64(c.ShortChannelID.BlockHeight)
+		}
 
 		// query spend hint for channel
 		hintCache, err := channeldb.NewHeightHintCache(channeldb.CacheConfig{

--- a/sync/channelswatcher.go
+++ b/sync/channelswatcher.go
@@ -126,7 +126,7 @@ func (b *ChannelsWatcher) Scan(tipHeight uint64) (bool, error) {
 
 	startHeight, err := b.db.fetchChannelsWatcherBlockHeight()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to fetch start height: %w", err)
 	}
 	b.log.Info("fetchChannelsWatcherBlockHeight = %v", startHeight)
 	if b.firstChannelBlockHeight > startHeight {
@@ -135,12 +135,12 @@ func (b *ChannelsWatcher) Scan(tipHeight uint64) (bool, error) {
 
 	startHash, err := b.chainService.GetBlockHash(int64(startHeight))
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get start block hash for start height %d: %w", startHeight, err)
 	}
 
 	tipHash, err := b.chainService.GetBlockHash(int64(tipHeight))
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get end block hash for end height %d: %w", tipHeight, err)
 	}
 
 	b.log.Infof("Scanning for closed channels in range %v-%v", startHeight, tipHeight)


### PR DESCRIPTION
The channels watcher uses the blockheight of channels to determine where to start the rescan. For zero conf channels, however, the short channel id contains the scid alias, so the blockheight is bogus. If the channel is zeroconf, the real blockheight sohuld be taken using `ZeroConfRealScid`.

This caused the chainsync job to fail, because the call to `startHash, err := b.chainService.GetBlockHash(int64(startHeight))` would fail if the blockheight didn't exist.