### PR TITLE
bump neutrino

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -215,6 +215,6 @@ replace (
 	github.com/btcsuite/btcwallet => github.com/breez/btcwallet v0.16.10-16b422a-breez
 	github.com/btcsuite/btcwallet/walletdb => github.com/breez/btcwallet/walletdb v1.4.0-breez
 	github.com/btcsuite/btcwallet/wtxmgr => github.com/breez/btcwallet/wtxmgr v1.5.1-0.20220717090508-739787f948a6
-	github.com/lightninglabs/neutrino => github.com/breez/neutrino v0.16.1-0.20240503110651-f94b53a3ce68
+	github.com/lightninglabs/neutrino => github.com/breez/neutrino v0.16.1-0.20240516143806-c27444dcb848
 	github.com/lightningnetwork/lnd => github.com/breez/lnd v0.17.5-breez
 )

--- a/go.sum
+++ b/go.sum
@@ -715,8 +715,8 @@ github.com/breez/lnd v0.17.5-breez h1:zJua5p5uWGzltjM8AD5P11g09wVcbrIdtX/8N2208J
 github.com/breez/lnd v0.17.5-breez/go.mod h1:ZwAMPHKSN2sGg0c8OQc+ihstHpXNi33qd/cscjRWLvk=
 github.com/breez/lspd v0.0.0-20230630175015-34646d50a591 h1:vSyn3d0GOlNWUaWtRtSwjwIS8+3qLLirVWN+flQOt3I=
 github.com/breez/lspd v0.0.0-20230630175015-34646d50a591/go.mod h1:sziWG8CyL2rBHr7d6ncxFiK2R3f18SRtOEcFeP7Rvz4=
-github.com/breez/neutrino v0.16.1-0.20240503110651-f94b53a3ce68 h1:fyLSLEFYhBZzAP01cc7MFiNt6QXaSaHghUT8wmQlSI4=
-github.com/breez/neutrino v0.16.1-0.20240503110651-f94b53a3ce68/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
+github.com/breez/neutrino v0.16.1-0.20240516143806-c27444dcb848 h1:7KtbJrot8IfcoEwBWcEPJdLPlKuLYwbsw4i8v8GaDYQ=
+github.com/breez/neutrino v0.16.1-0.20240516143806-c27444dcb848/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=


### PR DESCRIPTION
This neutrino bump changes the 'minimum'/'initial' query timeout from 4 to 10 seconds. The maximum timeout is bumped from 32 to 40 seconds.