### PR TITLE
ensure a single job is run at once

### DIFF
--- a/closedchannels/job.go
+++ b/closedchannels/job.go
@@ -30,7 +30,7 @@ Run executes the download filter operation synchronousely
 */
 func (s *Job) Run() error {
 	if !atomic.CompareAndSwapInt32(&jobIsRunning, 0, 1) {
-		return fmt.Errorf("job already running")
+		return nil
 	}
 	defer atomic.StoreInt32(&jobIsRunning, 0)
 

--- a/closedchannels/job.go
+++ b/closedchannels/job.go
@@ -23,10 +23,17 @@ const (
 	deletedSuffix   = ".deleted"
 )
 
+var jobIsRunning int32
+
 /*
 Run executes the download filter operation synchronousely
 */
 func (s *Job) Run() error {
+	if !atomic.CompareAndSwapInt32(&jobIsRunning, 0, 1) {
+		return fmt.Errorf("job already running")
+	}
+	defer atomic.StoreInt32(&jobIsRunning, 0)
+
 	s.wg.Add(1)
 	defer s.wg.Done()
 	bootstrapped, err := chainservice.Bootstrapped(s.workingDir)

--- a/sync/job.go
+++ b/sync/job.go
@@ -25,7 +25,7 @@ Run executes the download filter operation synchronousely
 */
 func (s *Job) Run() (channelClosed bool, err error) {
 	if !atomic.CompareAndSwapInt32(&jobIsRunning, 0, 1) {
-		return false, fmt.Errorf("job already running")
+		return false, nil
 	}
 	defer atomic.StoreInt32(&jobIsRunning, 0)
 

--- a/sync/job.go
+++ b/sync/job.go
@@ -18,10 +18,17 @@ const (
 	rateLimitJobInterval = time.Duration(time.Minute * 10)
 )
 
+var jobIsRunning int32
+
 /*
 Run executes the download filter operation synchronousely
 */
 func (s *Job) Run() (channelClosed bool, err error) {
+	if !atomic.CompareAndSwapInt32(&jobIsRunning, 0, 1) {
+		return false, fmt.Errorf("job already running")
+	}
+	defer atomic.StoreInt32(&jobIsRunning, 0)
+
 	s.wg.Add(1)
 	defer s.wg.Done()
 


### PR DESCRIPTION
Sometimes multiple sync jobs and/or multiple closedchannels jobs are run at the same time. This PR ensures the job is cancelled if another job is already running.