### PR TITLE
remove record channels status

### DIFF
--- a/app.go
+++ b/app.go
@@ -78,10 +78,6 @@ func (a *App) Start(torConfig *data.TorConfig) error {
 		a.BackupManager,
 	}
 
-	if err := a.lspChanStateSyncer.recordChannelsStatus(); err != nil {
-		a.log.Errorf("failed to collect channels state %v", err)
-	}
-
 	for _, s := range services {
 		if err := s.Start(); err != nil {
 			return err

--- a/db/syncstatus.go
+++ b/db/syncstatus.go
@@ -1,9 +1,5 @@
 package db
 
-import (
-	"encoding/json"
-)
-
 type MismatchedChannels struct {
 	LSPPubkey  string
 	ChanPoints []MismatchedChannel
@@ -26,31 +22,4 @@ func (db *DB) FetchLastSyncedHeaderTimestamp() (int64, error) {
 // SetLastSyncedHeaderTimestamp saves the last known header timestamp that the node is synced to.
 func (db *DB) SetLastSyncedHeaderTimestamp(ts int64) error {
 	return db.saveItem([]byte(syncstatus), []byte("last_header_timestamp"), itob(uint64(ts)))
-}
-
-func (db *DB) SetMismatchedChannels(mismatched *MismatchedChannels) error {
-	serialized, err := json.Marshal(mismatched)
-	if err != nil {
-		return err
-	}
-	return db.saveItem([]byte(syncstatus), []byte("mismatched_channels"), serialized)
-}
-
-func (db *DB) FetchMismatchedChannels() (*MismatchedChannels, error) {
-	raw, err := db.fetchItem([]byte(syncstatus), []byte("mismatched_channels"))
-	if err != nil {
-		return nil, err
-	}
-	if raw == nil {
-		return nil, nil
-	}
-	var mismatched MismatchedChannels
-	if err := json.Unmarshal(raw, &mismatched); err != nil {
-		return nil, err
-	}
-	return &mismatched, err
-}
-
-func (db *DB) RemoveChannelMismatch() error {
-	return db.deleteItem([]byte(syncstatus), []byte("mismatched_channels"))
 }

--- a/lsp_chan_state.go
+++ b/lsp_chan_state.go
@@ -1,18 +1,13 @@
 package breez
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
-	"strconv"
 	"strings"
 
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -34,18 +29,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type peerSnapshot struct {
-	pubKey          string
-	unconfirmedOpen map[string]uint64
-}
-
 type lspChanStateSync struct {
 	cfg       *config.Config
 	log       btclog.Logger
 	breezAPI  services.API
 	breezDB   *db.DB
 	daemonAPI lnnode.API
-	snapshots map[string]*peerSnapshot
 }
 
 func newLSPChanStateSync(app *App) *lspChanStateSync {
@@ -55,7 +44,6 @@ func newLSPChanStateSync(app *App) *lspChanStateSync {
 		daemonAPI: app.lnDaemon,
 		breezDB:   app.breezDB,
 		cfg:       app.cfg,
-		snapshots: make(map[string]*peerSnapshot, 0),
 	}
 }
 
@@ -144,212 +132,6 @@ func (a *lspChanStateSync) checkLSPClosedChannelMismatch(lspNodePubkey string, l
 	hasMismatch := len(unconfirmedClosed) > 0
 	a.log.Infof("checkLSPClosedChannelMismatch finished, hasMismatch = %v", hasMismatch)
 	return hasMismatch, nil
-}
-
-func (a *lspChanStateSync) recordChannelsStatus() error {
-	status, byOutpoint, err := a.collectChannelsStatus()
-	if err != nil {
-		return err
-	}
-	a.snapshots = status
-	channels, err := a.breezDB.FetchMismatchedChannels()
-	if err != nil {
-		return err
-	}
-	if channels != nil && len(channels.ChanPoints) > 0 {
-		a.log.Infof("found channels mismatch to purge: %v", channels.ChanPoints)
-		if err := a.commitHeightHint(channels.LSPPubkey, channels.ChanPoints); err != nil {
-			a.log.Errorf("failed to purge height hint for channels: %v error: %v", channels.ChanPoints, err)
-		}
-	}
-
-	for _, p := range status {
-		for cp := range p.unconfirmedOpen {
-			outpoint, err := parseOutpoint(cp)
-			if err != nil {
-				return err
-			}
-			hasFunding, err := a.hasActiveFundingWorkflow(outpoint)
-			if err != nil {
-				return err
-			}
-			a.log.Infof("channed point %v has funding - %v", cp, hasFunding)
-			if !hasFunding {
-				ch, ok := byOutpoint[cp]
-				if ok {
-					err = a.resetFundingFlow(outpoint, lnwire.NewShortChanIDFromInt(ch.ShortChanID().ToUint64()))
-					a.log.Infof("channed point %v reset funding short id = %v, err = %v", cp, ch.ShortChanID().ToUint64(), err)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	a.log.Infof("succesfully purged channels mismatch hints")
-	return a.breezDB.RemoveChannelMismatch()
-}
-
-func parseOutpoint(tx string) (*wire.OutPoint, error) {
-	txParts := strings.Split(tx, ":")
-	if len(txParts) != 2 {
-		return nil, errors.New("invalid outpoint")
-	}
-	hash, err := chainhash.NewHashFromStr(txParts[0])
-	if err != nil {
-		return nil, err
-	}
-	index, err := strconv.ParseUint(txParts[1], 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("invalid outpoint: %v", err)
-	}
-	return wire.NewOutPoint(hash, uint32(index)), nil
-}
-
-func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
-	scratch := make([]byte, 4)
-	if err := wire.WriteVarBytes(w, 0, o.Hash[:]); err != nil {
-		return err
-	}
-
-	binary.BigEndian.PutUint32(scratch, o.Index)
-	_, err := w.Write(scratch)
-	return err
-}
-
-func (a *lspChanStateSync) resetFundingFlow(chanPoint *wire.OutPoint,
-	shortChanID lnwire.ShortChannelID) error {
-
-	chandb, cleanup, err := channeldbservice.Get(a.cfg.WorkingDir)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-	return kvdb.Update(chandb, func(tx kvdb.RwTx) error {
-
-		bucket, err := tx.CreateTopLevelBucket([]byte("channelOpeningState"))
-		if err != nil {
-			return err
-		}
-
-		var outpointBytes bytes.Buffer
-
-		if err = writeOutpoint(&outpointBytes, chanPoint); err != nil {
-			return err
-		}
-
-		scratch := make([]byte, 10)
-		binary.BigEndian.PutUint16(scratch[:2], uint16(1))
-		binary.BigEndian.PutUint64(scratch[2:], shortChanID.ToUint64())
-
-		return bucket.Put(outpointBytes.Bytes(), scratch)
-	}, func() {})
-}
-
-func (a *lspChanStateSync) hasActiveFundingWorkflow(chanPoint *wire.OutPoint) (
-	bool, error) {
-
-	chandb, cleanup, err := channeldbservice.Get(a.cfg.WorkingDir)
-	if err != nil {
-		return false, err
-	}
-	defer cleanup()
-
-	var exists bool
-	err = kvdb.View(chandb, func(tx kvdb.RTx) error {
-
-		bucket := tx.ReadBucket([]byte("channelOpeningState"))
-		if bucket == nil {
-			return nil
-		}
-
-		var outpointBytes bytes.Buffer
-		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
-			return err
-		}
-
-		value := bucket.Get(outpointBytes.Bytes())
-		exists = value != nil
-		return nil
-	}, func() {})
-	if err != nil {
-		return false, err
-	}
-
-	return exists, nil
-}
-
-func (a *lspChanStateSync) collectChannelsStatus() (
-	map[string]*peerSnapshot, map[string]*channeldb.OpenChannel, error) {
-
-	snapshots := make(map[string]*peerSnapshot)
-
-	chandb, cleanup, err := channeldbservice.Get(a.cfg.WorkingDir)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer cleanup()
-
-	a.log.Infof("iterating old fake ids")
-	_ = kvdb.View(chandb, func(tx kvdb.RTx) error {
-		fakeIDsBucket := tx.ReadBucket([]byte("fake-short-channel-ids"))
-		if fakeIDsBucket == nil {
-			return nil
-		}
-		return fakeIDsBucket.ForEach(func(k, v []byte) error {
-			shortID := binary.BigEndian.Uint64(k)
-			a.log.Infof("fake channel id: %v", shortID, lnwire.NewShortChanIDFromInt(shortID).String())
-			return nil
-		})
-	}, func() {})
-
-	// query spend hint for channel
-	hintCache, err := channeldb.NewHeightHintCache(channeldb.CacheConfig{
-		QueryDisable: false,
-	}, chandb)
-
-	channels, err := chandb.ChannelStateDB().FetchAllChannels()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	channelsMap := make(map[string]*channeldb.OpenChannel, 0)
-	for _, c := range channels {
-		if !c.IsZeroConf() {
-			continue
-		}
-
-		// ignore fake chanels with pending htlcs.
-		if len(c.ActiveHtlcs()) > 0 {
-			continue
-		}
-
-		a.log.Infof("collecting status for channel id: %v", c.ShortChannelID.String())
-		peerPubkey := hex.EncodeToString(c.IdentityPub.SerializeCompressed())
-		a.log.Infof("collecting lsp channels for pubkey: %v", peerPubkey)
-		snapshot, ok := snapshots[peerPubkey]
-		if !ok {
-			snapshot = &peerSnapshot{
-				pubKey:          peerPubkey,
-				unconfirmedOpen: make(map[string]uint64, 0),
-			}
-			snapshots[peerPubkey] = snapshot
-		}
-
-		height, err := hintCache.QueryConfirmHint(chainntnfs.ConfRequest{TxID: c.FundingOutpoint.Hash})
-		if errors.Is(err, chainntnfs.ErrConfirmHintNotFound) {
-			height = 0
-		} else if err != nil {
-			return nil, nil, err
-		}
-		snapshot.unconfirmedOpen[c.FundingOutpoint.String()] = uint64(height)
-		channelsMap[c.FundingOutpoint.String()] = c
-		a.log.Infof("adding unconfirmed channel to query %v fundingHeight=%v hint=%v",
-			c.FundingOutpoint.Hash.String(), c.FundingBroadcastHeight, height)
-	}
-
-	return snapshots, channelsMap, nil
 }
 
 func (a *lspChanStateSync) checkChannels(fakeChannels, waitingCloseChannels map[string]uint64,


### PR DESCRIPTION
The recordChannelsStatus function would insert all zero conf channels into the channelOpeningState bucket. This causes the funding workflow for these channels to restart. When the funding flow restarts, LND will start searching for the funding transaction by scanning the chain backwards. This means as you have channels for a longer time, Breez would consume more and more bandwidth to sync the chain from tip to channel open height. By deleting this function, once the funding workflow is complete once, it won't be entered again.

Upon cleaning up it seems that SetMismatchedChannels was never used. So FetchMismatchedChannels and RemoveChannelMismatch could be removed as well.