### PR TITLE
identify no_route error as temporary_channel_failure

### DIFF
--- a/swapfunds/addfunds.go
+++ b/swapfunds/addfunds.go
@@ -520,7 +520,7 @@ func (s *Service) retryGetPayment(addressInfo *db.SwapAddressInfo, retries int) 
 }
 
 func isTemporaryChannelError(err string) bool {
-	return strings.Contains(err, "TemporaryChannelFailure")
+	return strings.Contains(err, "TemporaryChannelFailure") || strings.Contains(err, "no_route")
 }
 
 func (s *Service) getPayment(addressInfo *db.SwapAddressInfo) (bool, error) {


### PR DESCRIPTION
The actual error received on temporary_channel_failure currently is:
`rpc error: code = Unknown desc = error in payment response: no_route`