### PR TITLE
overflow check

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -147,6 +147,8 @@ func (a *Service) getMaxReceiveSingleChannel() (maxPay int64, err error) {
 		if maxAllowedReceive < thisChannelCanReceive {
 			maxAllowedReceive = thisChannelCanReceive
 		}
+
+		a.log.Debugf("Channel %v can receive %v, reserve %v, max allowed receive %v", b.ChannelPoint, thisChannelCanReceive, chanReserveSat, maxAllowedReceive)
 	}
 	return maxAllowedReceive, nil
 }

--- a/account/account.go
+++ b/account/account.go
@@ -128,7 +128,14 @@ func (a *Service) getMaxReceiveSingleChannel() (maxPay int64, err error) {
 
 	var maxAllowedReceive int64
 	for _, b := range channels.Channels {
-		thisChannelCanReceive := b.RemoteBalance - int64(b.RemoteConstraints.ChanReserveSat)
+		chanReserveSat := int64(b.RemoteConstraints.ChanReserveSat)
+		thisChannelCanReceive := b.RemoteBalance
+		if chanReserveSat < thisChannelCanReceive {
+			thisChannelCanReceive -= chanReserveSat
+		} else {
+			thisChannelCanReceive = 0
+		}
+
 		if !b.Initiator {
 			buffer := (b.CommitWeight + input.HTLCWeight) * 2 * b.FeePerKw / 1000
 			if buffer < thisChannelCanReceive {

--- a/account/payments.go
+++ b/account/payments.go
@@ -854,6 +854,8 @@ func (a *Service) AddInvoice(invoiceRequest *data.AddInvoiceRequest) (paymentReq
 	amountMsat := invoice.Amount * 1000
 	smallAmountMsat := amountMsat
 	needOpenChannel := maxReceiveMsat < amountMsat
+	a.log.Debugf("AddInvoice: amountMsat=%v, maxReceiveMsat=%v, needOpenChannel=%v", amountMsat, maxReceiveMsat, needOpenChannel)
+
 	var routingHints []*lnrpc.RouteHint
 
 	// We need the LSP to open a channel.


### PR DESCRIPTION
Check for overflow on calculating max receive for a channel.

Also log lines regarding the decision whether something is an open channel payment or not.

It appears sometimes invoices are created without an open channel route hint, while the amount obviously requires it.