### PR TITLE
Skip failed pending payment.

### DIFF
--- a/account/payments.go
+++ b/account/payments.go
@@ -1565,7 +1565,6 @@ func (a *Service) createPendingPayment(htlc *lnrpc.HTLC, currentBlockHeight uint
 		invoice, err := lnclient.LookupInvoice(context.Background(), &lnrpc.PaymentHash{RHash: htlc.HashLock})
 		if err != nil {
 			a.log.Errorf("createPendingPayment - failed to call LookupInvoice %v", err)
-			return nil, err
 		}
 		if invoice != nil {
 			paymentRequest = invoice.PaymentRequest


### PR DESCRIPTION
Currently if users restore while having pending payments the invoice is not found and an error is returned. This PR handles this case more gracefully.